### PR TITLE
[spark-vflbfgs] add mapJoinPartitions Operator (prepared for Vector-free LogisticRegression implementation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+.idea/
+*.iml
+

--- a/src/main/scala/org/apache/spark/ml/optim/VFRDDFunctions.scala
+++ b/src/main/scala/org/apache/spark/ml/optim/VFRDDFunctions.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.optim
+
+import java.io.{IOException, ObjectOutputStream}
+import java.util.HashMap
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+import org.apache.spark._
+import org.apache.spark.util.Utils
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+
+
+
+class MapJoinPartitionsPartition(
+    idx: Int,
+    @transient private val rdd1: RDD[_],
+    @transient private val rdd2: RDD[_],
+    s2IdxArr: Array[Int]) extends Partition {
+
+  var s1 = rdd1.partitions(idx)
+  var s2Arr = s2IdxArr.map(s2Idx => rdd2.partitions(s2Idx))
+  override val index: Int = idx
+
+  @throws(classOf[IOException])
+  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    s1 = rdd1.partitions(idx)
+    s2Arr = s2IdxArr.map(s2Idx => rdd2.partitions(s2Idx))
+    oos.defaultWriteObject()
+  }
+}
+
+class MapJoinPartitionsRDD[A: ClassTag, B: ClassTag, V: ClassTag](
+      sc: SparkContext,
+      var idxF: (Int) => Array[Int],
+      var f: (Int, Iterator[A], Array[(Int, Iterator[B])]) => Iterator[V],
+      var rdd1: RDD[A],
+      var rdd2: RDD[B])
+  extends RDD[V](sc, Nil) {
+
+  override val partitioner = None
+
+  override def getPartitions: Array[Partition] = {
+    val array = new Array[Partition](rdd1.partitions.length)
+    for (s1 <- rdd1.partitions) {
+      val idx = s1.index
+      array(idx) = new MapJoinPartitionsPartition(idx, rdd1, rdd2, idxF(idx))
+    }
+    array
+  }
+
+  override def getDependencies: Seq[Dependency[_]] = List(
+    new OneToOneDependency(rdd1),
+    new NarrowDependency(rdd2) {
+      override def getParents(partitionId: Int): Seq[Int] = {
+        idxF(partitionId)
+      }
+    }
+  )
+
+  override def getPreferredLocations(s: Partition): Seq[String] = {
+    val fp = firstParent[A]
+    // println(s"pref loc: ${fp.preferredLocations(fp.partitions(s.index))}")
+    fp.preferredLocations(fp.partitions(s.index))
+  }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[V] = {
+    val currSplit = split.asInstanceOf[MapJoinPartitionsPartition]
+    f(currSplit.s1.index, rdd1.iterator(currSplit.s1, context),
+      currSplit.s2Arr.map(s2 => (s2.index, rdd2.iterator(s2, context)))
+    )
+  }
+
+  override def clearDependencies() {
+    super.clearDependencies()
+    rdd1 = null
+    rdd2 = null
+    idxF = null
+    f = null
+  }
+}
+
+class VFRDDFunctions[A](self: RDD[A])
+                       (implicit at: ClassTag[A])
+extends Logging with Serializable {
+
+  def mapJoinPartition[B: ClassTag, V: ClassTag](rdd2: RDD[B])(
+    idxF: (Int) => Array[Int],
+    f: (Int, Iterator[A], Array[(Int, Iterator[B])]) => Iterator[V]
+  ) = self.withScope{
+    val sc = self.sparkContext
+    val cleanIdxF = sc.clean(idxF)
+    val cleanF = sc.clean(f)
+    new MapJoinPartitionsRDD(sc, cleanIdxF, cleanF, self, rdd2)
+  }
+}
+object VFRDDFunctions {
+  implicit def fromRDD[A: ClassTag](rdd: RDD[A]): VFRDDFunctions[A] = {
+    new VFRDDFunctions(rdd)
+  }
+}
+

--- a/src/main/scala/org/apache/spark/ml/optim/VFUtils.scala
+++ b/src/main/scala/org/apache/spark/ml/optim/VFUtils.scala
@@ -144,3 +144,86 @@ class GridPartitioner(val rows: Int, val cols: Int) extends Partitioner{
     }
   }
 }
+
+class GridPartitionerV2(
+                         val rows: Int,
+                         val cols: Int,
+                         val rowsPerPart: Int,
+                         val colsPerPart: Int) extends Partitioner {
+
+  require(rows > 0)
+  require(cols > 0)
+  require(rowsPerPart > 0)
+  require(colsPerPart > 0)
+
+  val rowPartitions = math.ceil(rows * 1.0 / rowsPerPart).toInt
+  val colPartitions = math.ceil(cols * 1.0 / colsPerPart).toInt
+
+  override val numPartitions: Int = rowPartitions * colPartitions
+
+  /**
+    * Returns the index of the partition the input coordinate belongs to.
+    *
+    * @param key The partition id i (calculated through this method for coordinate (i, j) in
+    *            `simulateMultiply`, the coordinate (i, j) or a tuple (i, j, k), where k is
+    *            the inner index used in multiplication. k is ignored in computing partitions.
+    * @return The index of the partition, which the coordinate belongs to.
+    */
+  override def getPartition(key: Any): Int = {
+    key match {
+      case i: Int => i
+      case (i: Int, j: Int) =>
+        getPartitionId(i, j)
+      case (i: Int, j: Int, _: Int) =>
+        getPartitionId(i, j)
+      case _ =>
+        throw new IllegalArgumentException(s"Unrecognized key: $key.")
+    }
+  }
+
+  /** Partitions sub-matrices as blocks with neighboring sub-matrices. */
+  private def getPartitionId(i: Int, j: Int): Int = {
+    require(0 <= i && i < rows, s"Row index $i out of range [0, $rows).")
+    require(0 <= j && j < cols, s"Column index $j out of range [0, $cols).")
+    i / rowsPerPart + j / colsPerPart * rowPartitions
+  }
+
+  def rowPartId(partId: Int) = partId % rowPartitions
+  def colPartId(partId: Int) = partId / rowPartitions
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case r: GridPartitionerV2 =>
+        (this.rows == r.rows) && (this.cols == r.cols) &&
+          (this.rowsPerPart == r.rowsPerPart) && (this.colsPerPart == r.colsPerPart)
+      case _ =>
+        false
+    }
+  }
+
+  override def hashCode: Int = {
+    com.google.common.base.Objects.hashCode(
+      rows: java.lang.Integer,
+      cols: java.lang.Integer,
+      rowsPerPart: java.lang.Integer,
+      colsPerPart: java.lang.Integer)
+  }
+}
+object GridPartitionerV2 {
+
+  /** Creates a new [[GridPartitionerV2]] instance. */
+  def apply(rows: Int, cols: Int, rowsPerPart: Int, colsPerPart: Int): GridPartitionerV2 = {
+    new GridPartitionerV2(rows, cols, rowsPerPart, colsPerPart)
+  }
+
+  /** Creates a new [[GridPartitionerV2]] instance with the input suggested number of partitions. */
+  def apply(rows: Int, cols: Int, suggestedNumPartitions: Int): GridPartitionerV2 = {
+    require(suggestedNumPartitions > 0)
+    val scale = 1.0 / math.sqrt(suggestedNumPartitions)
+    val rowsPerPart = math.round(math.max(scale * rows, 1.0)).toInt
+    val colsPerPart = math.round(math.max(scale * cols, 1.0)).toInt
+    new GridPartitionerV2(rows, cols, rowsPerPart, colsPerPart)
+  }
+}
+
+

--- a/src/test/scala/org/apache/spark/ml/optim/VFRDDFunctionsSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/optim/VFRDDFunctionsSuite.scala
@@ -1,0 +1,53 @@
+package org.apache.spark.ml.optim
+
+import org.scalatest.FunSuite
+import org.apache.spark.ml.linalg.DistributedVectorPartitioner
+import org.apache.spark.mllib.linalg.distributed.GridPartitioner
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+class VFRDDFunctionsSuite extends FunSuite with MLlibTestSparkContext {
+
+  import org.apache.spark.ml.optim.VFRDDFunctions._
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  test("mapJoinPartitions") {
+    val sc = spark.sparkContext
+    val rdd1 = sc.parallelize(Array.tabulate(81) {
+      idx => {
+        val rowIdx = idx % 9
+        val colIdx = idx / 9
+        ((rowIdx, colIdx), (rowIdx, colIdx))
+      }
+    }).partitionBy(GridPartitionerV2(9, 9, 3, 3)).cache()
+    rdd1.count()
+    val rdd2 = sc.parallelize(Array.tabulate(9)(idx => (idx, idx)))
+      .partitionBy(new DistributedVectorPartitioner(9)).cache()
+    rdd2.count()
+
+    val rddr = rdd1.mapJoinPartition(rdd2)(
+      (x: Int) => {
+        val blockColIdx = x / 3
+        val pos = blockColIdx * 3
+        Array(pos, pos + 1, pos + 2)
+      },
+      (p1: Int, iter1, list: Array[(Int, Iterator[(Int, Int)])]) => {
+        Iterator((p1, list.map(tuple => (tuple._1, tuple._2.next())).mkString(",")))
+      }
+    )
+    println("rddr:")
+    assert(rddr.collect() === Array(
+      (0, "(0,(0,0)),(1,(1,1)),(2,(2,2))"),
+      (1, "(0,(0,0)),(1,(1,1)),(2,(2,2))"),
+      (2, "(0,(0,0)),(1,(1,1)),(2,(2,2))"),
+      (3, "(3,(3,3)),(4,(4,4)),(5,(5,5))"),
+      (4, "(3,(3,3)),(4,(4,4)),(5,(5,5))"),
+      (5, "(3,(3,3)),(4,(4,4)),(5,(5,5))"),
+      (6, "(6,(6,6)),(7,(7,7)),(8,(8,8))"),
+      (7, "(6,(6,6)),(7,(7,7)),(8,(8,8))"),
+      (8, "(6,(6,6)),(7,(7,7)),(8,(8,8))")
+    ))
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
### 1. Add mapJoinPartitions Operator

this operator do something like map-side join between two RDD's partitions, but it provides more flexibility. The API defined as following:

```
def mapJoinPartition[B: ClassTag, V: ClassTag](rdd2: RDD[B])(
    idxF: (Int) => Array[Int],
    f: (Int, Iterator[A], Array[(Int, Iterator[B])]) => Iterator[V]
  )
```

this operator need two function parameter:
`idxF: (Int) => Array[Int]` define the mapping relation, determine which partitions of `RDD[B]` will be mapped to the relative `RDD[A]` partition. The input parameter is `RDD[A]` partition id, and the output parameter is the partitions id-list of `RDD[B]`, which will be mapped to the specified `RDD[A]` partition.

`f: (Int, Iterator[A], Array[(Int, Iterator[B])]) => Iterator[V]` is the user-defined calculation function. it contains 3 input parameter and 1 output iterator. parameter defined as following:
`f: (pid: Int, iterA: Iterator[A], iterBList: Array[(Int, Iterator[B])])`
pid is the partition id of `RDD[A]`
iterA is the content iterator of `RDD[A]`'s "pid" partition.
iterBList is an Array and each element is a pair of (pid_RDDB, iterB) represent the pid of `RDD[B]` and the corresponding `RDD[B]` partition iterator.

The task preferred locations of `mapJoinPartition` operator will keep consistent with `RDD[A]`, so that it will benefit from data locality, because usually `RDD[A]` will be much larger than `RDD[B]`.
### 2. Add GridPartitionerV2

It is similar to the `GridPartitioner` in spark mllib, but here I remove the private[mllib] restriction on the class and change two members `rowPartitions`, `colPartitions` into public. 
And add two methods `rowPartId`, `colPartId`.
## How was this patch tested?

Test class `VFRDDFunctionsSuite` added.
