### PR TITLE
Add scalatest plugin and update some test suites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <build>
+        <pluginManagement>
+            <plugins>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.scala-tools</groupId>
@@ -26,11 +30,63 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>2.6</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <version>1.0</version>
+                <!-- Note config is repeated in surefire config -->
+                <configuration>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                    <junitxml>.</junitxml>
+                    <filereports>SparkTestSuite.txt</filereports>
+                    <argLine>-ea -Xmx3g -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=128m</argLine>
+                    <stderr/>
+                    <environmentVariables>
+                        <!--
+                          Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes
+                          launched by the tests have access to the correct test-time classpath.
+                        -->
+                        <!--<SPARK_DIST_CLASSPATH>${test_classpath}</SPARK_DIST_CLASSPATH>-->
+                        <SPARK_PREPEND_CLASSES>1</SPARK_PREPEND_CLASSES>
+                        <SPARK_SCALA_VERSION>2.11</SPARK_SCALA_VERSION>
+                        <SPARK_TESTING>1</SPARK_TESTING>
+                        <JAVA_HOME>${env.JAVA_HOME}</JAVA_HOME>
+                    </environmentVariables>
+                    <systemProperties>
+                        <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
+                        <derby.system.durability>test</derby.system.durability>
+                        <java.awt.headless>true</java.awt.headless>
+                        <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
+                        <spark.test.home>${project.build.directory}/testHome</spark.test.home>
+                        <spark.testing>1</spark.testing>
+                        <spark.ui.enabled>false</spark.ui.enabled>
+                        <spark.ui.showConsoleProgress>false</spark.ui.showConsoleProgress>
+                        <spark.unsafe.exceptionOnMemoryLeak>true</spark.unsafe.exceptionOnMemoryLeak>
+                    </systemProperties>
+                    <!--<tagsToExclude>${test.exclude.tags}</tagsToExclude>-->
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>test</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the file target/unit-tests.log
+log4j.rootCategory=INFO, file
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=target/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.spark_project.jetty=WARN
+

--- a/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
@@ -88,9 +88,9 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
   test("VF binary logistic regression with weighted samples") {
     val (dataset, weightedDataset) = {
       val nPoints = 20
-      val coefficients = Array(-0.57997, 0.912083, -0.371077, -0.819866)
-      val xMean = Array(0.1, -0.1, 0.0, 0.1)
-      val xVariance = Array(0.6856, 0.1899, 3.116, 0.581)
+      val coefficients = Array(-0.57997, 0.912083)
+      val xMean = Array(0.1, -0.1)
+      val xVariance = Array(0.6856, 0.1899)
       val testData =
         generateMultinomialLogisticInput(coefficients, xMean, xVariance, false, nPoints, 42)
 

--- a/src/test/scala/org/apache/spark/ml/optim/VFUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/optim/VFUtilsSuite.scala
@@ -101,7 +101,7 @@ class VFUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       assert(v._1 == v._2 && v._3 == v._4)
       (v._2, v._3)
     }.sortBy(v => v._1 + v._2 * 1000)
-    println(s"arr res: ${res.mkString(",")}")
+    // println(s"arr res: ${res.mkString(",")}")
     assert(res === Array.tabulate(rows * cols)(idx => {
       val rowIdx = idx % rows
       val colIdx = idx / rows
@@ -128,7 +128,7 @@ class VFUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       assert(v._1 == v._3 && v._2 == v._4)
       (v._2, v._3)
     }.sortBy(v => v._1 + v._2 * 1000)
-    println(s"arr res: ${res.mkString(",")}")
+    // println(s"arr res: ${res.mkString(",")}")
     assert(res === Array.tabulate(rows * cols)(idx => {
       val rowIdx = idx % rows
       val colIdx = idx / rows


### PR DESCRIPTION
## What changes were proposed in this pull request?
- add scalatest maven plugin.
- disable surefire-plugin which is used for java class tests.
- add default `log4j.properties` as test resource.
- remove some print message in test suites.
- several updates in `LBFGSSuite`
## Test usage

running all tests, use command

```
mvn test
```

running parts of tests, use commands like following:

```
mvn test -DwildcardSuites=org.apache.spark.ml.optim
mvn test -DwildcardSuites=org.apache.spark.ml.classification.VLogisticRegressionSuite
```
