### PR TITLE
Fix rdd parallelize problem in sc.parallelize method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ target/
 .idea/
 *.iml
 git.*
+src/main/scala/org/apache/spark/ml/private
+
 

--- a/src/main/scala/org/apache/spark/ml/optim/VFUtils.scala
+++ b/src/main/scala/org/apache/spark/ml/optim/VFUtils.scala
@@ -38,7 +38,7 @@ object VFUtils {
       else splitArr(i) = arr.slice(partSize * i, arr.length)
       i += 1
     }
-    val rdd = sc.parallelize(splitArr.zipWithIndex.map(x => (x._2, Vectors.dense(x._1))))
+    val rdd = sc.parallelize(splitArr.zipWithIndex.map(x => (x._2, Vectors.dense(x._1))), partNum)
     kvRDDToDV(rdd, partSize, partNum, arr.length)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When initialize `DistributedVector` zero-vector, at `sc.parallelize`, add `sleep(1000)` into each map task so that it will help spread task into the whole cluster, or the tasks may be aggregates in a few cluster nodes, in my test.

This is a walk-round way for now, in the future if there is better way I will update it.

## How was this patch tested?

Manual.