### PR TITLE
Fix double-shuffling and parallelism limit problem in featureBlockMatrix initialization

### DIFF
--- a/src/main/scala/org/apache/spark/ml/optim/VFUtils.scala
+++ b/src/main/scala/org/apache/spark/ml/optim/VFUtils.scala
@@ -110,7 +110,7 @@ object VFUtils {
       dvec: DistributedVector,
       gridPartitioner: GridPartitionerV2,
       f: ((SparseMatrix, Vector) => T)
-  ) = {
+  ): RDD[((Int, Int), T)] = {
     import org.apache.spark.ml.optim.VFRDDFunctions._
     require(gridPartitioner.cols == dvec.nParts)
     blockMatrixRDD.mapJoinPartition(dvec.vecs)(
@@ -132,7 +132,7 @@ object VFUtils {
         mIter.map {
           block =>
             val vecPart = vMap(block._1._2)
-            (block._1._1, f(block._2, vecPart))
+            (block._1, f(block._2, vecPart))
         }
       }
     )
@@ -142,7 +142,7 @@ object VFUtils {
       dvec: DistributedVector,
       gridPartitioner: GridPartitionerV2,
       f: (((SparseMatrix, Vector) => T))
-  ) = {
+  ): RDD[((Int, Int), T)] = {
     import org.apache.spark.ml.optim.VFRDDFunctions._
     require(gridPartitioner.rows == dvec.nParts)
     blockMatrixRDD.mapJoinPartition(dvec.vecs)(
@@ -164,7 +164,7 @@ object VFUtils {
         mIter.map {
           block =>
             val horzPart = vMap(block._1._1)
-            (block._1._2, f(block._2, horzPart))
+            (block._1, f(block._2, horzPart))
         }
       }
     )

--- a/src/test/scala/org/apache/spark/ml/optim/VFUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/optim/VFUtilsSuite.scala
@@ -96,6 +96,7 @@ class VFUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       (sv(0, 0), sv(0, 1), v(0))
     }
     val res0 = VFUtils.blockMatrixHorzZipVec(blockMatrix, dvec, gridPartitioner, f)
+      .map(x => (x._1._1, x._2))
     val res = res0.map(v => (v._1, v._2._1.toInt, v._2._2.toInt, v._2._3.toInt))
       .collect().map{ v =>
       assert(v._1 == v._2 && v._3 == v._4)
@@ -123,6 +124,7 @@ class VFUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       (sv(0, 0), sv(0, 1), v(0))
     }
     val res0 = VFUtils.blockMatrixVertZipVec(blockMatrix, dvec, gridPartitioner, f)
+      .map(x => (x._1._2, x._2))
     val res = res0.map(v => (v._1, v._2._1.toInt, v._2._2.toInt, v._2._3.toInt))
       .collect().map{ v =>
       assert(v._1 == v._3 && v._2 == v._4)


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Fix parallelism limit problem in featureBlockMatrix initialization.
When shuffle feature data and aggregate into featureBlockMatrix, change the partitioner to `GridPartitionerV2` so it will have good parallelism, and avoiding shuffling again when doing the feature standardization, and also update code logic for the following feature standardization(change it from using `zipPartition` into using `blockMatrixHorzZipVec`).

- Modify `blockMatrixHorzZipVec` &  `blockMatrixVertZipVec` API returned type into `RDD[((Int, Int), T)]`

### How was this patch tested?

Existing test.
`VFUtilsSuite` test updated.