### PR TITLE
Add VectorSummarizer & improve VLOR aggregating code

### DIFF
--- a/src/main/scala/org/apache/spark/ml/linalg/DistributedVector.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/DistributedVector.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.ml.linalg
 
 import org.apache.spark.{Partitioner, SparkContext}

--- a/src/main/scala/org/apache/spark/ml/optim/VectorFreeLBFGS.scala
+++ b/src/main/scala/org/apache/spark/ml/optim/VectorFreeLBFGS.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.ml.optim
 
 import breeze.optimize.{DiffFunction, StepSizeUnderflow, StrongWolfeLineSearch}

--- a/src/main/scala/org/apache/spark/rdd/MapJoinPartitionsRDD.scala
+++ b/src/main/scala/org/apache/spark/rdd/MapJoinPartitionsRDD.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.rdd
 
 import java.io.{IOException, ObjectOutputStream}

--- a/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
+++ b/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.rdd
 
 import scala.reflect.ClassTag

--- a/src/test/scala/org/apache/spark/ml/classification/RealDataSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/classification/RealDataSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.ml.classification
 
 import org.apache.spark.SparkFunSuite

--- a/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.ml.classification
 
 import scala.language.existentials

--- a/src/test/scala/org/apache/spark/ml/linalg/DistributedVectorSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/linalg/DistributedVectorSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.ml.linalg
 
 import breeze.linalg.{norm => Bnorm, DenseVector => BDV}

--- a/src/test/scala/org/apache/spark/ml/optim/VectorFreeLBFGSSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/optim/VectorFreeLBFGSSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.ml.optim
 
 import java.util.Random

--- a/src/test/scala/org/apache/spark/ml/util/VUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/util/VUtilsSuite.scala
@@ -1,8 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.ml.util
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.rdd.RDD
 import org.apache.spark.ml.linalg._
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
 import scala.reflect.ClassTag
@@ -168,6 +187,21 @@ class VUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
     testBlockMatrixVertZipVecFunc(5, 3, 5, 3)
     testBlockMatrixVertZipVecFunc(4, 15, 1, 6)
     testBlockMatrixVertZipVecFunc(3, 15, 2, 6)
+  }
+
+  test("vector summarizer") {
+    val testRDD: RDD[Vector] = sc.parallelize(Seq(
+      Vectors.dense(1.0, 2.0, 3.0),
+      Vectors.dense(2.0, 0.0, 0.0),
+      Vectors.dense(5.0, 2.0, 1.0),
+      Vectors.dense(-4.0, 2.0, 1.0)
+    ), 3)
+    val result = testRDD.aggregate(new VectorSummarizer)(
+      (s: VectorSummarizer, v: Vector) => s.add(v),
+      (s1: VectorSummarizer, s2: VectorSummarizer) => s1.merge(s2)
+    ).toDenseVector
+
+    assert(result ~== Vectors.dense(4.0, 6.0, 5.0) relTol 1e-3)
   }
 }
 

--- a/src/test/scala/org/apache/spark/rdd/VRDDFunctionsSuite.scala
+++ b/src/test/scala/org/apache/spark/rdd/VRDDFunctionsSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.rdd
 
 import org.apache.spark.SparkFunSuite


### PR DESCRIPTION
1. add `VectorSummarizer` 

2. improve VLOR aggregating vectors code, replace `reduceByKey` with `aggregateByKey` using `VectorSummarizer`

3. In `VBinomialLogisticCostFun` before shuffle vectors, call `Vector.compressed` to reduce shuffling data size.

3. add licenses for codes.