### PR TITLE
Add VLogisticRegression intercept support

### DIFF
--- a/src/main/scala/org/apache/spark/ml/optim/VectorFreeLBFGS.scala
+++ b/src/main/scala/org/apache/spark/ml/optim/VectorFreeLBFGS.scala
@@ -113,6 +113,7 @@ class VectorFreeLBFGS(
       } catch {
         case x: Exception =>
           state.convergenceFlag = SearchFailedFlag
+          x.printStackTrace(System.err)
           state
       }
     }
@@ -131,7 +132,7 @@ class VectorFreeLBFGS(
           logInfo("Vector-Free LBFGS gradient converged.")
           true
         case SearchFailedFlag =>
-          logInfo("Vector-Free LBFGS search failed.")
+          logError("Vector-Free LBFGS search failed.")
           true
       }
       if (isFinished) history.dispose

--- a/src/main/scala/org/apache/spark/ml/util/VUtils.scala
+++ b/src/main/scala/org/apache/spark/ml/util/VUtils.scala
@@ -137,7 +137,7 @@ private[ml] object VUtils {
       blockMatrixRDD: RDD[((Int, Int), SparseMatrix)],
       dvec: DistributedVector,
       gridPartitioner: GridPartitionerV2,
-      f: ((SparseMatrix, Vector) => T)
+      f: (((Int, Int), SparseMatrix, Vector) => T)
   ): RDD[((Int, Int), T)] = {
     import org.apache.spark.rdd.VRDDFunctions._
     require(gridPartitioner.cols == dvec.nParts)
@@ -159,7 +159,7 @@ private[ml] object VUtils {
         }
         mIter.map { case ((rowBlockIdx: Int, colBlockIdx: Int), sm: SparseMatrix) =>
           val vecPart = vMap(colBlockIdx)
-          ((rowBlockIdx, colBlockIdx), f(sm, vecPart))
+          ((rowBlockIdx, colBlockIdx), f((rowBlockIdx, colBlockIdx), sm, vecPart))
         }
       }
     )
@@ -169,7 +169,7 @@ private[ml] object VUtils {
       blockMatrixRDD: RDD[((Int, Int), SparseMatrix)],
       dvec: DistributedVector,
       gridPartitioner: GridPartitionerV2,
-      f: (((SparseMatrix, Vector) => T))
+      f: (((Int, Int), SparseMatrix, Vector) => T)
   ): RDD[((Int, Int), T)] = {
     import org.apache.spark.rdd.VRDDFunctions._
     require(gridPartitioner.rows == dvec.nParts)
@@ -191,7 +191,7 @@ private[ml] object VUtils {
         }
         mIter.map { case ((rowBlockIdx: Int, colBlockIdx: Int), sm: SparseMatrix) =>
           val horzPart = vMap(rowBlockIdx)
-          ((rowBlockIdx, colBlockIdx), f(sm, horzPart))
+          ((rowBlockIdx, colBlockIdx), f((rowBlockIdx, colBlockIdx), sm, horzPart))
         }
       }
     )

--- a/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
@@ -45,6 +45,7 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
     val df1 = spark.createDataFrame(sc.parallelize(data1, 2))
 
     val vtrainer = new VLogisticRegression()
+      .setFitIntercept(false)
       .setColsPerBlock(3)
       .setRowsPerBlock(2)
       .setWeightCol("weight")
@@ -64,10 +65,38 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
     assert(vmodel.coefficients.toLocal ~== model.coefficients relTol 1E-5)
   }
 
+  test("test on data1, w/ weight, L2 reg = 0, w/ intercept") {
+    val df1 = spark.createDataFrame(sc.parallelize(data1, 2))
+
+    val vtrainer = new VLogisticRegression()
+      .setFitIntercept(true)
+      .setColsPerBlock(3)
+      .setRowsPerBlock(2)
+      .setWeightCol("weight")
+      .setRegParam(0.0)
+      .setStandardization(true)
+    val vmodel = vtrainer.fit(df1)
+
+    val trainer = new LogisticRegression()
+      .setFitIntercept(true)
+      .setWeightCol("weight")
+      .setRegParam(0.0)
+      .setStandardization(true)
+    val model = trainer.fit(df1)
+
+    println(s"VLogisticRegression coefficients: ${vmodel.coefficients.toLocal}\n" +
+      s"LogisticRegression coefficients: ${model.coefficients}")
+    assert(vmodel.coefficients.toLocal ~== model.coefficients relTol 1E-5)
+    println(s"VLogisticRegression intercept: ${vmodel.intercept}\n" +
+      s"LogisticRegression intercept: ${model.intercept}")
+    assert(vmodel.intercept ~== model.intercept relTol 1E-5)
+  }
+
   test("test on data1, w/o weight, L2 reg = 0, w/o intercept") {
     val df1 = spark.createDataFrame(sc.parallelize(data1, 2))
 
     val vtrainer = new VLogisticRegression()
+      .setFitIntercept(false)
       .setColsPerBlock(2)
       .setRowsPerBlock(3)
       .setRegParam(0.0)
@@ -85,10 +114,36 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
     assert(vmodel.coefficients.toLocal ~== model.coefficients relTol 1E-5)
   }
 
+  test("test on data1, w/o weight, L2 reg = 0, w/ intercept") {
+    val df1 = spark.createDataFrame(sc.parallelize(data1, 2))
+
+    val vtrainer = new VLogisticRegression()
+      .setFitIntercept(true)
+      .setColsPerBlock(2)
+      .setRowsPerBlock(3)
+      .setRegParam(0.0)
+      .setStandardization(true)
+    val vmodel = vtrainer.fit(df1)
+
+    val trainer = new LogisticRegression()
+      .setFitIntercept(true)
+      .setRegParam(0.0)
+      .setStandardization(true)
+    val model = trainer.fit(df1)
+
+    println(s"VLogisticRegression coefficients: ${vmodel.coefficients.toLocal}\n" +
+      s"LogisticRegression coefficients: ${model.coefficients}")
+    assert(vmodel.coefficients.toLocal ~== model.coefficients relTol 1E-5)
+    println(s"VLogisticRegression intercept: ${vmodel.intercept}\n" +
+      s"LogisticRegression intercept: ${model.intercept}")
+    assert(vmodel.intercept ~== model.intercept relTol 1E-5)
+  }
+
   test("test on data1, w/ weight, L2 reg = 0.8, w/ standardize, w/o intercept") {
     val df1 = spark.createDataFrame(sc.parallelize(data1, 2))
 
     val vtrainer = new VLogisticRegression()
+      .setFitIntercept(false)
       .setColsPerBlock(1)
       .setRowsPerBlock(1)
       .setColPartitions(3)
@@ -110,10 +165,40 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
     assert(vmodel.coefficients.toLocal ~== model.coefficients relTol 1E-5)
   }
 
+  test("test on data1, w/ weight, L2 reg = 0.8, w/ standardize, w/ intercept") {
+    val df1 = spark.createDataFrame(sc.parallelize(data1, 2))
+
+    val vtrainer = new VLogisticRegression()
+      .setFitIntercept(true)
+      .setColsPerBlock(1)
+      .setRowsPerBlock(1)
+      .setColPartitions(3)
+      .setRowPartitions(2)
+      .setWeightCol("weight")
+      .setRegParam(0.8)
+      .setStandardization(true)
+    val vmodel = vtrainer.fit(df1)
+
+    val trainer = new LogisticRegression()
+      .setFitIntercept(true)
+      .setWeightCol("weight")
+      .setRegParam(0.8)
+      .setStandardization(true)
+    val model = trainer.fit(df1)
+
+    println(s"VLogisticRegression coefficients: ${vmodel.coefficients.toLocal}\n" +
+      s"LogisticRegression coefficient: ${model.coefficients}")
+    assert(vmodel.coefficients.toLocal ~== model.coefficients relTol 1E-5)
+    println(s"VLogisticRegression intercept: ${vmodel.intercept}\n" +
+      s"LogisticRegression intercept: ${model.intercept}")
+    assert(vmodel.intercept ~== model.intercept relTol 1E-5)
+  }
+
   test("test on data1, w/ weight, L2 reg = 0.8, w/o standardize, w/o intercept") {
     val df1 = spark.createDataFrame(sc.parallelize(data1, 2))
 
     val vtrainer = new VLogisticRegression()
+      .setFitIntercept(false)
       .setColsPerBlock(4)
       .setRowsPerBlock(5)
       .setWeightCol("weight")
@@ -131,6 +216,33 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
     println(s"VLogisticRegression coefficients: ${vmodel.coefficients.toLocal}\n" +
       s"LogisticRegression coefficient: ${model.coefficients}")
     assert(vmodel.coefficients.toLocal ~== model.coefficients relTol 1E-5)
+  }
+
+  test("test on data1, w/ weight, L2 reg = 0.8, w/o standardize, w/ intercept") {
+    val df1 = spark.createDataFrame(sc.parallelize(data1, 2))
+
+    val vtrainer = new VLogisticRegression()
+      .setFitIntercept(true)
+      .setColsPerBlock(4)
+      .setRowsPerBlock(5)
+      .setWeightCol("weight")
+      .setRegParam(0.8)
+      .setStandardization(false)
+    val vmodel = vtrainer.fit(df1)
+
+    val trainer = new LogisticRegression()
+      .setFitIntercept(true)
+      .setWeightCol("weight")
+      .setRegParam(0.8)
+      .setStandardization(false)
+    val model = trainer.fit(df1)
+
+    println(s"VLogisticRegression coefficients: ${vmodel.coefficients.toLocal}\n" +
+      s"LogisticRegression coefficient: ${model.coefficients}")
+    assert(vmodel.coefficients.toLocal ~== model.coefficients relTol 1E-5)
+    println(s"VLogisticRegression intercept: ${vmodel.intercept}\n" +
+      s"LogisticRegression intercept: ${model.intercept}")
+    assert(vmodel.intercept ~== model.intercept relTol 1E-5)
   }
 
   test("VLogisticRegression (binary) w/ weighted samples") {
@@ -180,6 +292,7 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
     }
 
     val vtrainer1 = new VLogisticRegression()
+      .setFitIntercept(false)
       .setColsPerBlock(2)
       .setRowsPerBlock(2)
       .setColPartitions(2)
@@ -187,6 +300,7 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
       .setRegParam(0.0)
       .setStandardization(true)
     val vtrainer2 = new VLogisticRegression()
+      .setFitIntercept(false)
       .setColsPerBlock(2)
       .setRowsPerBlock(2)
       .setColPartitions(3)

--- a/src/test/scala/org/apache/spark/ml/util/VUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/util/VUtilsSuite.scala
@@ -111,7 +111,7 @@ class VUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
     val blockMatrix = sc.parallelize(arrMatrix).partitionBy(gridPartitioner)
     val arrVec = Array.tabulate(cols)(idx => idx.toDouble)
     val dvec = splitArrIntoDV(sc, arrVec, 1, cols)
-    val f = (sv: SparseMatrix, v: Vector) => {
+    val f = (blockCoords: (Int, Int), sv: SparseMatrix, v: Vector) => {
       (sv(0, 0), sv(0, 1), v(0))
     }
     val res0 = blockMatrixHorzZipVec(blockMatrix, dvec, gridPartitioner, f)
@@ -142,7 +142,7 @@ class VUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
     val blockMatrix = sc.parallelize(arrMatrix).partitionBy(gridPartitioner)
     val arrVec = Array.tabulate(rows)(idx => idx.toDouble)
     val dvec = VUtils.splitArrIntoDV(sc, arrVec, 1, rows)
-    val f = (sv: SparseMatrix, v: Vector) => {
+    val f = (blockCoords: (Int, Int), sv: SparseMatrix, v: Vector) => {
       (sv(0, 0), sv(0, 1), v(0))
     }
     val res0 = VUtils.blockMatrixVertZipVec(blockMatrix, dvec, gridPartitioner, f)


### PR DESCRIPTION
Add VLogisticRegression intercept support.

The implementation for `intercept` is similar to the one in spark mllib. The key point is following:

1. When training, store `intercept` value in the last element of the `coefficients` DV.
2. In `VBinomialLogisticCostFun`, when calculating `margins`, fetch `intercept` value from the last element of the `coefficients` DV and add it into `margin`.
3. When aggregating `features` vector into `gradient`, append a virtual column using value `1`, and aggregate them using each `multiplier`.
4. The Logistic Regression intercept use a computed value as initial value:
```
initial_intercept = \log{P(1) / P(0)} = \log{count_1 / count_0}
```

**Note**
The `standardization` processing do not include `intercept`.
The L2 regulization do not include `intercept`.

**API change**
Add `blockCoords: (Int, Int)` parameter for `f` in `VUtils.blockMatrixHorzZipVec` and `VUtils.blockMatrixHorzZipVec`.




