### PR TITLE
fix VectorFreeLBFGS memory leak & omission of RDD step-persist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ data/
 .idea/
 *.iml
 git.*
-src/main/scala/org/apache/spark/ml/private
+src/main/scala/org/apache/spark/ml/privatecode
 
 

--- a/src/main/scala/org/apache/spark/ml/classification/VLogisticRegression.scala
+++ b/src/main/scala/org/apache/spark/ml/classification/VLogisticRegression.scala
@@ -444,7 +444,7 @@ private[ml] class VBinomialLogisticCostFun(
           i += 1
         }
         Vectors.dense(partGradsArr)
-      }
+    }
 
     val gradDV: DV = new DV(grad, colsPerBlock, colBlocks,
       if (fitIntercept) numFeatures + 1 else numFeatures

--- a/src/main/scala/org/apache/spark/ml/example/RosenbrockExample.scala
+++ b/src/main/scala/org/apache/spark/ml/example/RosenbrockExample.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.example
+
+import java.util.Random
+
+import breeze.linalg.{DenseVector => BDV}
+import org.apache.spark.SparkContext
+import org.apache.spark.ml.linalg.DistributedVector
+import org.apache.spark.ml.optim.{DVDiffFunction, VectorFreeLBFGS}
+import org.apache.spark.ml.util.VUtils
+import org.apache.spark.sql.SparkSession
+
+object RosenbrockExample {
+
+  def rangeRandDouble(x: Double, y: Double, rand: Random): Double ={
+    x + (y - x) * rand.nextDouble()
+  }
+
+  def runRosenbrock(
+    sc: SparkContext,
+    bm: Int,
+    maxIter: Int,
+    dimension: Int,
+    partSize: Int): Unit = {
+
+    val rand = new Random(100)
+
+    val partNum = VUtils.getNumBlocks(partSize, dimension)
+    println(s"----------run bm=$bm, dimension=$dimension, maxIter=$maxIter, partNum=${partNum}---------")
+
+    val vf_lbfgs = new VectorFreeLBFGS(maxIter, bm)
+
+    val initData: Array[Double] = Array.fill(dimension)(0.0)
+      .map(x => rangeRandDouble(-10D, 10D, rand))
+
+    val initDisV = VUtils.splitArrIntoDV(sc, initData, partSize, partNum).eagerPersist()
+
+    def calc(x: BDV[Double]): (Double, BDV[Double]) = {
+
+      var fx = 0.0
+      val g = BDV.zeros[Double](x.length)
+
+      for(i <- 0 until x.length by 2) {
+        val t1 = 1.0 - x(i)
+        val t2 = 10.0 * (x(i + 1) - (x(i) * x(i)))
+        g(i + 1) = 20 * t2
+        g(i) = -2 * (x(i) * g(i + 1) + t1)
+        fx += t1 * t1 + t2 * t2
+      }
+      fx -> g
+    }
+
+    val vf_df = new DVDiffFunction {
+      def calculate(x: DistributedVector) = {
+        val r = calc(new BDV(x.toLocal.toArray))
+        val rr = r._2.toArray
+        (r._1, VUtils.splitArrIntoDV(sc, rr, partSize, partNum).eagerPersist())
+      }
+    }
+
+    val vf_lbfgsIter = vf_lbfgs.iterations(vf_df, initDisV)
+
+    var vf_state: vf_lbfgs.State = null
+
+    var iterCnt = 0
+    while (vf_lbfgsIter.hasNext) {
+      iterCnt += 1
+      System.out.print(s"press ENTER to start iter: ${iterCnt}")
+      System.out.flush()
+      System.in.read()
+      vf_state = vf_lbfgsIter.next()
+    }
+    println("iteration finish.")
+    println(s"result coeffs: ${vf_state.x.toLocal.toString}")
+  }
+
+  def main(args: Array[String]) = {
+    val spark = SparkSession
+      .builder()
+      .appName("Rosenbrock Example")
+      .config("spark.ui.enabled", true)
+      .config("spark.ui.port", 8899)
+      .getOrCreate()
+
+    println("UI port: 8899")
+
+    val sc = spark.sparkContext
+
+    runRosenbrock(sc,
+      bm = 4,
+      maxIter = 100,
+      dimension = 100,
+      partSize = 10)
+
+    sc.stop()
+  }
+}

--- a/src/main/scala/org/apache/spark/ml/example/VLORRealDataExample.scala
+++ b/src/main/scala/org/apache/spark/ml/example/VLORRealDataExample.scala
@@ -15,25 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.spark.ml.classification
+package org.apache.spark.ml.example
 
-import org.apache.spark.SparkFunSuite
-import org.apache.spark.ml.util.TestingUtils._
-import org.apache.spark.mllib.util.MLlibTestSparkContext
-import org.apache.spark.sql.Dataset
+import org.apache.spark.ml.classification.{LogisticRegression, VLogisticRegression}
+import org.apache.spark.sql.{Dataset, SparkSession}
 
-class RealDataSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+object VLORRealDataExample {
 
   // https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html#a9a
-  @transient var dataset1: Dataset[_] = _
+  def main(args: Array[String]) = {
+    val spark = SparkSession
+      .builder()
+      .appName("VLogistic Regression real data example")
+      .getOrCreate()
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
+    val sc = spark.sparkContext
 
-    dataset1 = spark.read.format("libsvm").load("data/a9a")
-  }
+    var dataset1: Dataset[_] = spark.read.format("libsvm").load("data/a9a")
 
-  ignore("a9a") {
     val trainer = new LogisticRegression()
       .setFitIntercept(false)
       .setRegParam(0.5)
@@ -47,7 +47,9 @@ class RealDataSuite extends SparkFunSuite with MLlibTestSparkContext {
       .setRegParam(0.5)
     val vmodel = vtrainer.fit(dataset1)
 
-    assert(vmodel.coefficients.toLocal ~== model.coefficients relTol 1E-3)
-  }
+    println(s"VLogistic regression coefficients: ${vmodel.coefficients.toLocal}")
+    println(s"Logistic regression coefficients: ${model.coefficients}")
 
+    sc.stop()
+  }
 }

--- a/src/test/scala/org/apache/spark/ml/optim/VectorFreeLBFGSSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/optim/VectorFreeLBFGSSuite.scala
@@ -31,7 +31,9 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 
 class VectorFreeLBFGSSuite extends SparkFunSuite with MLlibTestSparkContext {
 
-  def rangeRandDouble(x: Double, y: Double, rand: Random): Double = x + (y - x) * rand.nextDouble()
+  def rangeRandDouble(x: Double, y: Double, rand: Random): Double ={
+    x + (y - x) * rand.nextDouble()
+  }
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -91,9 +93,6 @@ class VectorFreeLBFGSSuite extends SparkFunSuite with MLlibTestSparkContext {
     val lbfgs = new BreezeLBFGS[BDV[Double]](maxIter, bm)
     val vf_lbfgs = new VectorFreeLBFGS(maxIter, bm)
 
-    // FIX: dimension == 4, hasNext != , when iter == 94
-    // FIX: dimension == 10, hasNext != , when iter == 99
-
     val initData: Array[Double] = Array.fill(dimension)(0.0)
       .map(x => rangeRandDouble(-10D, 10D, rand))
 
@@ -149,10 +148,8 @@ class VectorFreeLBFGSSuite extends SparkFunSuite with MLlibTestSparkContext {
     for (bm <- 4 to 10) {
       for (dimension <- 4 to 6 by 2) {
         testRosenbrock(bm, 10, dimension)
-        // println(s"bm=$bm, dimension=$dimension test passed.")
       }
     }
-    // println("test done.(useVector-free true)")
   }
 
 }

--- a/src/test/scala/org/apache/spark/rdd/VRDDFunctionsSuite.scala
+++ b/src/test/scala/org/apache/spark/rdd/VRDDFunctionsSuite.scala
@@ -54,7 +54,7 @@ class VRDDFunctionsSuite extends SparkFunSuite with MLlibTestSparkContext {
         Iterator((p1, list.map(tuple => (tuple._1, tuple._2.next())).mkString(",")))
       }
     )
-    println("rddr:")
+
     assert(rddr.collect() === Array(
       (0, "(0,(0,0)),(1,(1,1)),(2,(2,2))"),
       (1, "(0,(0,0)),(1,(1,1)),(2,(2,2))"),


### PR DESCRIPTION
* Unpersist useless coeffs DV and grads DV generated by `VLineSearchDiffFunction` in the next iteration, avoid memory leak.

* Persist the result of `VectorFreeLBFGS.takeStep`, avoid re-compute the coeffs DV in each iteration.

* Add RosenbrockExample, usage:
```
mvn clean package -DskipTests  # it will generate `spark-vlbfgs-1.0-SNAPSHOT.jar` in target directory.
spark-submit
   --master yarn
   --num-executors 3
   --executor-cores 2
   --class org.apache.spark.ml.example.RosenbrockExample
   /path/to/spark-vlbfgs-1.0-SNAPSHOT.jar
```
and open UI URL:  http://driverhost:8899 to check running status.

* Move `RealDataSuite` into example as `VLORRealDataExample`.

* Several minor updates in testcases.
