### PR TITLE
Add rdd persist check in VLOR

### DIFF
--- a/src/main/scala/org/apache/spark/ml/example/VLORExample.scala
+++ b/src/main/scala/org/apache/spark/ml/example/VLORExample.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.example
+
+import org.apache.spark.ml.classification.{LogisticRegression, VLogisticRegression}
+import org.apache.spark.sql.{Dataset, SparkSession}
+
+object VLORExample {
+
+  def main(args: Array[String]) = {
+
+    var maxIter: Int = 100
+
+    var dimension: Int = 780
+    var colsPerBlock: Int = 100
+    var rowsPerBlock: Int = 10
+    var colPartitions: Int = 3
+    var rowPartitions: Int = 3
+    var regParam: Double = 0.5
+    var fitIntercept: Boolean = true
+
+    var eagerPersist = true
+    var openUI = true
+
+    var dataPath: String = null
+
+    try {
+      maxIter = args(0).toInt
+
+      dimension = args(1).toInt
+
+      colsPerBlock = args(2).toInt
+      rowsPerBlock = args(3).toInt
+      colPartitions = args(4).toInt
+      rowPartitions = args(5).toInt
+      regParam = args(6).toDouble
+      fitIntercept = args(7).toBoolean
+
+      eagerPersist = args(8).toBoolean
+      openUI = args(9).toBoolean
+
+      dataPath = args(10)
+
+    } catch {
+      case _: Throwable =>
+        println("Wrong params.")
+        println("Params: "
+          + "maxIter dimension colsPerBlock rowsPerBlock colPartitions rowPartitions"
+          + " regParam fitIntercept eagerPersist openUI dataPath")
+        System.exit(-1)
+    }
+
+    val spark = SparkSession
+      .builder()
+      .appName("VLogistic Regression Example")
+      .config("spark.ui.enabled", openUI)
+      .config("spark.ui.port", 8899)
+      .getOrCreate()
+
+    if (openUI) println("UI port: 8899")
+
+    val sc = spark.sparkContext
+
+    try {
+      println(s"begin load data from ${dataPath}")
+      val dataset1: Dataset[_] = spark.read.format("libsvm")
+        .option("numFeatures", dimension.toString)
+        .load(dataPath)
+
+      val vtrainer = new VLogisticRegression()
+        .setMaxIter(maxIter)
+        .setColsPerBlock(colsPerBlock)
+        .setRowsPerBlock(rowsPerBlock)
+        .setColPartitions(colPartitions)
+        .setRowPartitions(rowPartitions)
+        .setRegParam(regParam)
+        .setFitIntercept(fitIntercept)
+        .setEagerPersist(eagerPersist)
+
+      val vmodel = vtrainer.fit(dataset1)
+
+      println(s"VLogistic regression coefficients: ${vmodel.coefficients.toLocal}")
+    } finally {
+      println("Press ENTER to exit.")
+      System.in.read()
+    }
+    sc.stop()
+  }
+
+}

--- a/src/main/scala/org/apache/spark/ml/example/VLORRealDataExample.scala
+++ b/src/main/scala/org/apache/spark/ml/example/VLORRealDataExample.scala
@@ -32,7 +32,7 @@ object VLORRealDataExample {
 
     val sc = spark.sparkContext
 
-    var dataset1: Dataset[_] = spark.read.format("libsvm").load("data/a9a")
+    val dataset1: Dataset[_] = spark.read.format("libsvm").load("data/a9a")
 
     val trainer = new LogisticRegression()
       .setFitIntercept(false)

--- a/src/main/scala/org/apache/spark/util/RDDUtils.scala
+++ b/src/main/scala/org/apache/spark/util/RDDUtils.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.{RDDBlockId, StorageLevel}
+
+private[spark] object RDDUtils {
+
+  /**
+   * Check whether the rdd is actually persisted. (because after calling `rdd.persist`
+   * the rdd is lazy persisted)
+   * @param rdd
+   */
+  def isRDDRealPersisted[T](rdd: RDD[T]): Boolean = {
+    if (rdd.partitions.length == 0)
+      return true
+
+    // only check partition-0
+    val blockId = RDDBlockId(rdd.id, 0)
+    SparkEnv.get.blockManager.get(blockId) match {
+      case Some(block) => true
+      case _ => false
+    }
+  }
+
+  def isRDDPersisted[T](rdd: RDD[T]): Boolean = {
+    rdd.getStorageLevel != StorageLevel.NONE
+  }
+
+}

--- a/src/test/scala/org/apache/spark/ml/linalg/DistributedVectorSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/linalg/DistributedVectorSuite.scala
@@ -48,9 +48,9 @@ class DistributedVectorSuite extends SparkFunSuite with MLlibTestSparkContext {
     val partSize = 3
     val partNum = VUtils.getNumBlocks(partSize, V1Array.length)
 
-    DV1 = VUtils.splitArrIntoDV(sc, V1Array, partSize, partNum).eagerPersist()
-    DV2 = VUtils.splitArrIntoDV(sc, V2Array, partSize, partNum).eagerPersist()
-    DV3 = VUtils.splitArrIntoDV(sc, V3Array, partSize, partNum).eagerPersist()
+    DV1 = VUtils.splitArrIntoDV(sc, V1Array, partSize, partNum).persist()
+    DV2 = VUtils.splitArrIntoDV(sc, V2Array, partSize, partNum).persist()
+    DV3 = VUtils.splitArrIntoDV(sc, V3Array, partSize, partNum).persist()
   }
 
   test("toLocal") {
@@ -59,19 +59,19 @@ class DistributedVectorSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("add") {
-    val local1 = DV1.add(2.0).eagerPersist().toLocal
-    val local2 = DV1.add(DV2).eagerPersist().toLocal
+    val local1 = DV1.add(2.0).persist().toLocal
+    val local2 = DV1.add(DV2).persist().toLocal
     assert(local1 ~== Vectors.fromBreeze(BV1 + 2.0) relTol 1e-8)
     assert(local2 ~== Vectors.fromBreeze(BV1 + BV2) relTol 1e-8)
   }
 
   test("scale") {
-    val local1 = DV1.scale(2.0).eagerPersist().toLocal
+    val local1 = DV1.scale(2.0).persist().toLocal
     assert(local1 ~== Vectors.fromBreeze(BV1 * 2.0) relTol 1e-8)
   }
 
   test("addScalVec") {
-    val res = DV1.addScalVec(3.0, DV2).eagerPersist().toLocal
+    val res = DV1.addScalVec(3.0, DV2).persist().toLocal
     assert(res ~== Vectors.fromBreeze(BV1 + (BV2 * 3.0)) relTol 1e-8)
   }
 
@@ -90,7 +90,7 @@ class DistributedVectorSuite extends SparkFunSuite with MLlibTestSparkContext {
   test("combine") {
     val combineVecLocal = DistributedVectors.combine(
       (10.0, DV1), (100.0, DV2), (18.0, DV3)
-    ).eagerPersist().toLocal
+    ).persist().toLocal
     val bCombineVec = (BV1 * 10.0) + (BV2 * 100.0) + (BV3 * 18.0)
     assert(combineVecLocal ~== Vectors.fromBreeze(bCombineVec) relTol 1e-8)
   }

--- a/src/test/scala/org/apache/spark/util/RDDUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/util/RDDUtilsSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import org.apache.spark.{SharedSparkContext, SparkFunSuite}
+
+class RDDUtilsSuite extends SparkFunSuite with SharedSparkContext {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  test("isRDDRealPersisted & isRDDPersisted") {
+
+    val rdd = sc.parallelize(Seq(1, 2, 3), 3).map(_ + 10)
+
+    assert(!RDDUtils.isRDDPersisted(rdd))
+    assert(!RDDUtils.isRDDRealPersisted(rdd))
+
+    rdd.persist()
+
+    assert(RDDUtils.isRDDPersisted(rdd))
+    assert(!RDDUtils.isRDDRealPersisted(rdd))
+
+    rdd.count() // eager persist
+
+    assert(RDDUtils.isRDDPersisted(rdd))
+    assert(RDDUtils.isRDDRealPersisted(rdd))
+  }
+
+}


### PR DESCRIPTION
* Add `isRDDPersisted` and `isRDDRealPersisted` helper methods.

* Add RDD persist check in VLOR code and VF-LBFGS code

* Add `eagerPersist` param for VLOR and VF-LBFGS, controlling whether to eagerly persist DistributedVector RDDs.

* several small optimization in codes.

* Add `VLORExample`