### PR TITLE
fix vector free LBFGS numeric stability for Si Yi computing in LBFGS

### DIFF
--- a/src/main/scala/org/apache/spark/ml/classification/VLogisticRegression.scala
+++ b/src/main/scala/org/apache/spark/ml/classification/VLogisticRegression.scala
@@ -322,6 +322,7 @@ class VLogisticRegression(override val uid: String)
     }
 
     val rawCoeffs = state.x // `x` already persisted.
+    assert(rawCoeffs.isPersisted)
 
     // println(s"rawCoeffs: ${rawCoeffs.toLocal.toString}")
 

--- a/src/test/scala/org/apache/spark/ml/optim/NumericStabilitySuite.scala
+++ b/src/test/scala/org/apache/spark/ml/optim/NumericStabilitySuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.optim
+
+import java.util.Random
+
+import breeze.linalg.{DenseVector => BDV}
+import breeze.optimize.{DiffFunction => BDF, LBFGS => BreezeLBFGS}
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.linalg.{DistributedVector, Vectors}
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.ml.util.TestingUtils._
+import org.apache.spark.ml.util.VUtils
+
+class NumericStabilitySuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+}
+

--- a/src/test/scala/org/apache/spark/ml/optim/VectorFreeLBFGSSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/optim/VectorFreeLBFGSSuite.scala
@@ -136,10 +136,12 @@ class VectorFreeLBFGSSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     while (lbfgsIter.hasNext) {
       state = lbfgsIter.next()
+      println(s"br_x${state.iter}: ${state.x}")
     }
 
     while (vf_lbfgsIter.hasNext) {
       vf_state = vf_lbfgsIter.next()
+      println(s"vf_x${vf_state.iter}: ${vf_state.x.toLocal}")
     }
 
     assert(vf_state.x.toLocal ~== Vectors.fromBreeze(state.x) relTol 0.1)


### PR DESCRIPTION
Previously, when computing LBFGS descent direction, only cache last m+1 coeffs and grad vectors.
Do not directly computing Si , Yi vectors.
This may cause numeric problem.
Update the code to compute Si, Yi first and cache them as history.
*For bug check, preserve old implementation for now.*
New implementation as `VectorFreeLBFGS.History2`, the old one as `VectorFreeLBFGS.History1`
and add a parameter `useNewHistoryClass`, default is `true`.