### PR TITLE
Optimize mapJoinPartitions by shuffle dependency

### DIFF
--- a/src/main/scala/org/apache/spark/ml/example/VLORExample.scala
+++ b/src/main/scala/org/apache/spark/ml/example/VLORExample.scala
@@ -37,6 +37,7 @@ object VLORExample {
     var elasticNetParam = 1.0
 
     var dataPath: String = null
+    var shuffleRDD2: Boolean = true
 
     try {
       maxIter = args(0).toInt
@@ -53,7 +54,6 @@ object VLORExample {
       elasticNetParam = args(9).toDouble
 
       dataPath = args(10)
-
     } catch {
       case _: Throwable =>
         println("Param list: "

--- a/src/main/scala/org/apache/spark/ml/util/VUtils.scala
+++ b/src/main/scala/org/apache/spark/ml/util/VUtils.scala
@@ -171,6 +171,8 @@ private[ml] object VUtils {
     }.collect()
   }
 
+  final val mapJoinPartitionsShuffleRdd2 =
+    System.getProperty("vflbfgs.mapJoinPartitions.shuffleRdd2", "true").toBoolean
 
   def blockMatrixHorzZipVec[T: ClassTag](
       blockMatrixRDD: RDD[((Int, Int), SparseMatrix)],
@@ -180,7 +182,7 @@ private[ml] object VUtils {
   ): RDD[((Int, Int), T)] = {
     import org.apache.spark.rdd.VRDDFunctions._
     require(gridPartitioner.cols == dvec.numBlocks)
-    blockMatrixRDD.mapJoinPartition(dvec.blocks)(
+    blockMatrixRDD.mapJoinPartition(dvec.blocks, mapJoinPartitionsShuffleRdd2)(
       (pid: Int) => {  // pid is the partition ID of blockMatrix RDD
         val colPartId = gridPartitioner.colPartId(pid)
         val startIdx = colPartId * gridPartitioner.colsPerPart
@@ -212,7 +214,7 @@ private[ml] object VUtils {
   ): RDD[((Int, Int), T)] = {
     import org.apache.spark.rdd.VRDDFunctions._
     require(gridPartitioner.rows == dvec.numBlocks)
-    blockMatrixRDD.mapJoinPartition(dvec.blocks)(
+    blockMatrixRDD.mapJoinPartition(dvec.blocks, mapJoinPartitionsShuffleRdd2)(
       (pid: Int) => {
         val rowPartId = gridPartitioner.rowPartId(pid)
         val startIdx = rowPartId * gridPartitioner.rowsPerPart

--- a/src/main/scala/org/apache/spark/rdd/MapJoinPartitionsRDDV2.scala
+++ b/src/main/scala/org/apache/spark/rdd/MapJoinPartitionsRDDV2.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import java.io.{IOException, ObjectOutputStream}
+
+import org.apache.spark.serializer.Serializer
+import org.apache.spark.{TaskContext, _}
+import org.apache.spark.util.Utils
+
+import scala.reflect.ClassTag
+
+class MapJoinPartitionsPartitionV2(
+    idx: Int,
+    @transient private val rdd1: RDD[_],
+    @transient private val rdd2: RDD[_],
+    s2IdxArr: Array[Int]) extends Partition {
+
+  var s1 = rdd1.partitions(idx)
+  var s2Arr = s2IdxArr.map(s2Idx => rdd2.partitions(s2Idx))
+  override val index: Int = idx
+
+  @throws(classOf[IOException])
+  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    s1 = rdd1.partitions(idx)
+    s2Arr = s2IdxArr.map(s2Idx => rdd2.partitions(s2Idx))
+    oos.defaultWriteObject()
+  }
+}
+
+class MapJoinPartitionsRDDV2[A: ClassTag, B: ClassTag, V: ClassTag](
+    sc: SparkContext,
+    var idxF: (Int) => Array[Int],
+    var f: (Int, Iterator[A], Array[(Int, Iterator[B])]) => Iterator[V],
+    var rdd1: RDD[A],
+    var rdd2: RDD[B])
+  extends RDD[V](sc, Nil) {
+
+  var rdd2WithPid = rdd2.mapPartitionsWithIndex((pid, iter) => iter.map(x => (pid, x)))
+
+  override val partitioner = None
+
+  private var serializer: Serializer = SparkEnv.get.serializer
+
+  override def getPartitions: Array[Partition] = {
+    val array = new Array[Partition](rdd1.partitions.length)
+    for (s1 <- rdd1.partitions) {
+      val idx = s1.index
+      array(idx) = new MapJoinPartitionsPartitionV2(idx, rdd1, rdd2, idxF(idx))
+    }
+    array
+  }
+
+  override def getDependencies: Seq[Dependency[_]] = List(
+    new OneToOneDependency(rdd1),
+    new ShuffleDependency[Int, B, B](
+      rdd2WithPid.asInstanceOf[RDD[_ <: Product2[Int, B]]],
+      new IdentityPartitioner(rdd2WithPid.getNumPartitions), serializer)
+  )
+
+  override def getPreferredLocations(s: Partition): Seq[String] = {
+    val fp = firstParent[A]
+    // println(s"pref loc: ${fp.preferredLocations(fp.partitions(s.index))}")
+    fp.preferredLocations(fp.partitions(s.index))
+  }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[V] = {
+    val currSplit = split.asInstanceOf[MapJoinPartitionsPartitionV2]
+    val rdd2Dep = dependencies(1).asInstanceOf[ShuffleDependency[Int, Any, Any]]
+    f(currSplit.s1.index, rdd1.iterator(currSplit.s1, context),
+      currSplit.s2Arr.map(s2 => (s2.index,
+        SparkEnv.get.shuffleManager
+          .getReader[Int, B](rdd2Dep.shuffleHandle, s2.index, s2.index + 1, context)
+          .read().map(x => x._2)
+        ))
+    )
+  }
+
+  override def clearDependencies() {
+    super.clearDependencies()
+    rdd1 = null
+    rdd2 = null
+    rdd2WithPid = null
+    idxF = null
+    f = null
+  }
+}
+
+private[spark] class IdentityPartitioner(val numParts: Int) extends Partitioner {
+  require(numPartitions > 0)
+  override def getPartition(key: Any): Int = key.asInstanceOf[Int]
+  override def numPartitions: Int = numParts
+}

--- a/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
+++ b/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
@@ -24,14 +24,20 @@ private[spark] class VRDDFunctions[A](self: RDD[A])
     (implicit at: ClassTag[A])
   extends Logging with Serializable {
 
-  def mapJoinPartition[B: ClassTag, V: ClassTag](rdd2: RDD[B])(
+  def mapJoinPartition[B: ClassTag, V: ClassTag](rdd2: RDD[B], shuffleRdd2: Boolean)(
     idxF: (Int) => Array[Int],
     f: (Int, Iterator[A], Array[(Int, Iterator[B])]) => Iterator[V]
   ) = self.withScope{
     val sc = self.sparkContext
     val cleanIdxF = sc.clean(idxF)
     val cleanF = sc.clean(f)
-    new MapJoinPartitionsRDD(sc, cleanIdxF, cleanF, self, rdd2)
+    if (shuffleRdd2) {
+      new MapJoinPartitionsRDDV2(sc, cleanIdxF, cleanF, self, rdd2)
+    }
+    else {
+      logWarning("mapJoinPartition not shuffle RDD2")
+      new MapJoinPartitionsRDD(sc, cleanIdxF, cleanF, self, rdd2)
+    }
   }
 }
 

--- a/src/test/scala/org/apache/spark/ml/util/VUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/util/VUtilsSuite.scala
@@ -110,7 +110,8 @@ class VUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
     )).toDense == Matrices.dense(3, 2, Array(1.0, 3.0, 7.0, 2.0, 8.0, 9.0)))
   }
 
-  def testBlockMatrixHorzZipVecFunc(rows: Int, cols: Int, rowsPerPart: Int, colsPerPart: Int) = {
+  def testBlockMatrixHorzZipVecFunc(rows: Int, cols: Int, rowsPerPart: Int, colsPerPart: Int,
+      shuffleRdd2: Boolean) = {
     val arrMatrix = Array.tabulate(rows * cols) { idx =>
       val rowIdx = idx % rows
       val colIdx = idx / rows
@@ -141,7 +142,8 @@ class VUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
     })
   }
 
-  def testBlockMatrixVertZipVecFunc(rows: Int, cols: Int, rowsPerPart: Int, colsPerPart: Int) = {
+  def testBlockMatrixVertZipVecFunc(rows: Int, cols: Int, rowsPerPart: Int, colsPerPart: Int,
+      shuffleRdd2: Boolean) = {
     val arrMatrix = Array.tabulate(rows * cols) { idx =>
       val rowIdx = idx % rows
       val colIdx = idx / rows
@@ -173,31 +175,55 @@ class VUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("blockMatrixHorzZipVec") {
-    testBlockMatrixHorzZipVecFunc(5, 4, 2, 3)
-    testBlockMatrixHorzZipVecFunc(8, 6, 2, 3)
-    testBlockMatrixHorzZipVecFunc(3, 5, 3, 5)
-    testBlockMatrixHorzZipVecFunc(15, 4, 6, 1)
-    testBlockMatrixHorzZipVecFunc(15, 3, 6, 2)
+    testBlockMatrixHorzZipVecFunc(5, 4, 2, 3, false)
+    testBlockMatrixHorzZipVecFunc(8, 6, 2, 3, false)
+    testBlockMatrixHorzZipVecFunc(3, 5, 3, 5, false)
+    testBlockMatrixHorzZipVecFunc(15, 4, 6, 1, false)
+    testBlockMatrixHorzZipVecFunc(15, 3, 6, 2, false)
 
-    testBlockMatrixHorzZipVecFunc(4, 5, 3, 2)
-    testBlockMatrixHorzZipVecFunc(6, 8, 3, 2)
-    testBlockMatrixHorzZipVecFunc(5, 3, 5, 3)
-    testBlockMatrixHorzZipVecFunc(4, 15, 1, 6)
-    testBlockMatrixHorzZipVecFunc(3, 15, 2, 6)
+    testBlockMatrixHorzZipVecFunc(4, 5, 3, 2, false)
+    testBlockMatrixHorzZipVecFunc(6, 8, 3, 2, false)
+    testBlockMatrixHorzZipVecFunc(5, 3, 5, 3, false)
+    testBlockMatrixHorzZipVecFunc(4, 15, 1, 6, false)
+    testBlockMatrixHorzZipVecFunc(3, 15, 2, 6, false)
+
+    testBlockMatrixHorzZipVecFunc(5, 4, 2, 3, true)
+    testBlockMatrixHorzZipVecFunc(8, 6, 2, 3, true)
+    testBlockMatrixHorzZipVecFunc(3, 5, 3, 5, true)
+    testBlockMatrixHorzZipVecFunc(15, 4, 6, 1, true)
+    testBlockMatrixHorzZipVecFunc(15, 3, 6, 2, true)
+
+    testBlockMatrixHorzZipVecFunc(4, 5, 3, 2, true)
+    testBlockMatrixHorzZipVecFunc(6, 8, 3, 2, true)
+    testBlockMatrixHorzZipVecFunc(5, 3, 5, 3, true)
+    testBlockMatrixHorzZipVecFunc(4, 15, 1, 6, true)
+    testBlockMatrixHorzZipVecFunc(3, 15, 2, 6, true)
   }
 
   test("blockMatrixVertZipVec") {
-    testBlockMatrixVertZipVecFunc(5, 4, 2, 3)
-    testBlockMatrixVertZipVecFunc(8, 6, 2, 3)
-    testBlockMatrixVertZipVecFunc(3, 5, 3, 5)
-    testBlockMatrixVertZipVecFunc(15, 4, 6, 1)
-    testBlockMatrixVertZipVecFunc(15, 3, 6, 2)
+    testBlockMatrixVertZipVecFunc(5, 4, 2, 3, false)
+    testBlockMatrixVertZipVecFunc(8, 6, 2, 3, false)
+    testBlockMatrixVertZipVecFunc(3, 5, 3, 5, false)
+    testBlockMatrixVertZipVecFunc(15, 4, 6, 1, false)
+    testBlockMatrixVertZipVecFunc(15, 3, 6, 2, false)
 
-    testBlockMatrixVertZipVecFunc(4, 5, 3, 2)
-    testBlockMatrixVertZipVecFunc(6, 8, 3, 2)
-    testBlockMatrixVertZipVecFunc(5, 3, 5, 3)
-    testBlockMatrixVertZipVecFunc(4, 15, 1, 6)
-    testBlockMatrixVertZipVecFunc(3, 15, 2, 6)
+    testBlockMatrixVertZipVecFunc(4, 5, 3, 2, false)
+    testBlockMatrixVertZipVecFunc(6, 8, 3, 2, false)
+    testBlockMatrixVertZipVecFunc(5, 3, 5, 3, false)
+    testBlockMatrixVertZipVecFunc(4, 15, 1, 6, false)
+    testBlockMatrixVertZipVecFunc(3, 15, 2, 6, false)
+
+    testBlockMatrixVertZipVecFunc(5, 4, 2, 3, true)
+    testBlockMatrixVertZipVecFunc(8, 6, 2, 3, true)
+    testBlockMatrixVertZipVecFunc(3, 5, 3, 5, true)
+    testBlockMatrixVertZipVecFunc(15, 4, 6, 1, true)
+    testBlockMatrixVertZipVecFunc(15, 3, 6, 2, true)
+
+    testBlockMatrixVertZipVecFunc(4, 5, 3, 2, true)
+    testBlockMatrixVertZipVecFunc(6, 8, 3, 2, true)
+    testBlockMatrixVertZipVecFunc(5, 3, 5, 3, true)
+    testBlockMatrixVertZipVecFunc(4, 15, 1, 6, true)
+    testBlockMatrixVertZipVecFunc(3, 15, 2, 6, true)
   }
 
   test("vector summarizer") {

--- a/src/test/scala/org/apache/spark/rdd/VRDDFunctionsSuite.scala
+++ b/src/test/scala/org/apache/spark/rdd/VRDDFunctionsSuite.scala
@@ -30,7 +30,7 @@ class VRDDFunctionsSuite extends SparkFunSuite with MLlibTestSparkContext {
     super.beforeAll()
   }
 
-  test("mapJoinPartitions") {
+  def testMapJoinPartitions(shuffleRdd2: Boolean): Unit = {
     val sc = spark.sparkContext
     val rdd1 = sc.parallelize(Array.tabulate(81) {
       idx => {
@@ -44,7 +44,7 @@ class VRDDFunctionsSuite extends SparkFunSuite with MLlibTestSparkContext {
       .partitionBy(new DistributedVectorPartitioner(9)).cache()
     rdd2.count()
 
-    val rddr = rdd1.mapJoinPartition(rdd2)(
+    val rddr = rdd1.mapJoinPartition(rdd2, shuffleRdd2)(
       (x: Int) => {
         val blockColIdx = x / 3
         val pos = blockColIdx * 3
@@ -66,5 +66,13 @@ class VRDDFunctionsSuite extends SparkFunSuite with MLlibTestSparkContext {
       (7, "(6,(6,6)),(7,(7,7)),(8,(8,8))"),
       (8, "(6,(6,6)),(7,(7,7)),(8,(8,8))")
     ))
+  }
+
+  test("mapJoinPartitions V1") {
+    testMapJoinPartitions(false)
+  }
+
+  test("mapJoinPartitions V2") {
+    testMapJoinPartitions(true)
   }
 }


### PR DESCRIPTION
Optimize mapJoinPartitions, change `RDD2` into shuffle dependency.
So that `RDD2` partitions won't be re-serialization and re-computation when iterating.

Keep old codes and add a new class `MapJoinPartitionsRDDV2`, and add java option `vflbfgs.mapJoinPartitions.shuffleRdd2`, when this option set `true`, will use new implementation, else use the old one.