### PR TITLE
Optimize VF-LBFGS by multi-zip partition RDD

### DIFF
--- a/src/main/scala/org/apache/spark/rdd/MultiZippedPartitionRDD.scala
+++ b/src/main/scala/org/apache/spark/rdd/MultiZippedPartitionRDD.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+import scala.reflect.ClassTag
+
+private[spark] class MultiZippedPartitionsRDD[A: ClassTag, V: ClassTag](
+    sc: SparkContext,
+    var f: (List[Iterator[A]]) => Iterator[V],
+    var rddList: List[RDD[A]],
+    preservesPartitioning: Boolean = false)
+  extends ZippedPartitionsBaseRDD[V](sc, rddList, preservesPartitioning) {
+
+  override def compute(s: Partition, context: TaskContext): Iterator[V] = {
+    val partitions = s.asInstanceOf[ZippedPartitionsPartition].partitions
+    val iterList = rddList.zipWithIndex.map{ case (rdd: RDD[A], index: Int) =>
+      rdd.iterator(partitions(index), context)
+    }
+    f(iterList)
+  }
+
+  override def clearDependencies() {
+    super.clearDependencies()
+    rddList = null
+    f = null
+  }
+}

--- a/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
+++ b/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
@@ -40,4 +40,15 @@ private[spark] object VRDDFunctions {
   implicit def fromRDD[A: ClassTag](rdd: RDD[A]): VRDDFunctions[A] = {
     new VRDDFunctions(rdd)
   }
+
+  def zipMultiRDDs[A: ClassTag, V: ClassTag](rddList: List[RDD[A]])
+      (f: (List[Iterator[A]]) => Iterator[V]) = {
+    assert(rddList.length > 1)
+    rddList(0).withScope{
+      val sc = rddList(0).sparkContext
+      val cleanF = sc.clean(f)
+      new MultiZippedPartitionsRDD[A, V](sc, cleanF, rddList)
+    }
+  }
+
 }

--- a/src/test/scala/org/apache/spark/rdd/VRDDSuite.scala
+++ b/src/test/scala/org/apache/spark/rdd/VRDDSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import org.apache.spark.{SharedSparkContext, SparkFunSuite}
+
+class VRDDSuite extends SparkFunSuite with SharedSparkContext {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  test("test multiZipRDDs") {
+    val rdd1 = sc.makeRDD(Array(1, 2, 3, 4), 2)
+    val rddList = List(rdd1, rdd1.map(_ + 10), rdd1.map(_ + 200))
+    val zipped = VRDDFunctions.zipMultiRDDs(rddList) {
+      iterList: List[Iterator[Int]] => new Iterator[Int]{
+        override def hasNext: Boolean = iterList.map(_.hasNext).reduce(_ && _)
+        override def next(): Int = iterList.map(_.next()).sum
+      }
+    }
+    assert(zipped.glom().map(_.toList).collect().toList ===
+      List(List(213, 216), List(219, 222)))
+  }
+}


### PR DESCRIPTION
Add `VRDDFunctions.zipMultiRDDs` method, it can zip multiple RDDs (the API in spark can only zip 4 rdds at most).
Optimize VF-LBFGS dot product computation by multi-zip partition RDD, so that it can avoid redundant RDD partition reading. (see comments for detail.)
Optimize `DistributedVector.combine` using `VRDDFunctions.zipMultiRDDs`, replace shuffling multiple RDDs.
