### PR TITLE
Add COO sparse matrix optimization

### DIFF
--- a/src/main/scala/org/apache/spark/ml/linalg/VCOOMatrix.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/VCOOMatrix.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.linalg
+
+import java.util.Arrays
+
+/**
+ * Row major COO format matrix.
+ * It will use less storage space than `ml.linalg.SparseMatrix`,
+ * when the matrix is extremely sparse (for example, each row contains less than one
+ * nonzero element in average)
+ */
+class VCOOMatrix(
+    override val numRows: Int,
+    override val numCols: Int,
+    private val rowIndices: Array[Int],
+    private val colIndices: Array[Int],
+    private val values: Array[Double]) extends VMatrix {
+
+  /**
+   * Returns an iterator of row vectors.
+   */
+  override def rowIter: Iterator[Vector] = {
+    val zeroRow = new SparseVector(numCols, new Array[Int](0), new Array[Double](0))
+
+    if (values.length == 0) {
+      Iterator.continually(zeroRow).take(numRows)
+    } else {
+      var prevRowIndex = rowIndices(0)
+      var prevRowIndexPtr = 0
+      val iter = (rowIndices.toIterator ++ Iterator.single(numRows)).zipWithIndex.flatMap {
+        case (rowIndex: Int, rowIndexPtr: Int) =>
+          if (rowIndex == prevRowIndex) {
+            Iterator.empty
+          } else {
+            val headElem = new SparseVector(numCols,
+              colIndices.slice(prevRowIndexPtr, rowIndexPtr),
+              values.slice(prevRowIndexPtr, rowIndexPtr)
+            )
+            assert(rowIndex > prevRowIndex)
+
+            val emptyRowIter = Iterator.continually(zeroRow).take(rowIndex - prevRowIndex - 1)
+
+            prevRowIndex = rowIndex
+            prevRowIndexPtr = rowIndexPtr
+
+            Iterator.single(headElem) ++ emptyRowIter
+          }
+      }
+      Iterator.continually(zeroRow).take(prevRowIndex) ++ iter
+    }
+  }
+
+  /**
+   * Applies a function `f` to all the active elements of dense and sparse matrix. The ordering
+   * of the elements are not defined.
+   *
+   * @param f the function takes three parameters where the first two parameters are the row
+   *          and column indices respectively with the type `Int`, and the final parameter is the
+   *          corresponding value in the matrix with type `Double`.
+   */
+  private[spark] override def foreachActive(f: (Int, Int, Double) => Unit) = {
+    var i = 0
+    while (i < values.length) {
+      f(rowIndices(i), colIndices(i), values(i))
+      i += 1
+    }
+  }
+
+  override def numActives: Int = values.length
+
+}

--- a/src/main/scala/org/apache/spark/ml/linalg/VCompressedCOOMatrix.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/VCompressedCOOMatrix.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.linalg
+
+/**
+ * Compressed version for `VCOOMatrix`
+ * Each entry of COO list use 24 bit integer pair as the coodinate,
+ * and value use `float` instead of `double`
+ */
+
+class VCompressedCOOMatrix(
+    override val numRows: Int,
+    override val numCols: Int,
+    private val rowIndices: Array[Byte],
+    private val colIndices: Array[Byte],
+    private val values: Array[Float]) extends VMatrix {
+
+  assert(numRows >= 0 && numRows < (1 << 24))
+  assert(numCols >= 0 && numCols < (1 << 24))
+
+  private def get24BitInt(arr: Array[Byte], index: Int): Int = {
+    val b1 = arr(index * 3) & 255
+    val b2 = arr(index * 3 + 1) & 255
+    val b3 = arr(index * 3 + 2) & 255
+
+    val res = (b1 | (b2 << 8) | (b3 << 16))
+    res
+  }
+
+  override def rowIter: Iterator[Vector] = {
+    val zeroRow = new SparseVector(numCols, new Array[Int](0), new Array[Double](0))
+
+    if (values.length == 0) {
+      Iterator.continually(zeroRow).take(numRows)
+    } else {
+      var prevRowIndex = get24BitInt(rowIndices, 0)
+      var prevRowIndexPtr = 0
+      val iter = (rowIndices.toIterator.grouped(3).map(x => get24BitInt(x.toArray, 0))
+        ++ Iterator.single(numRows)).zipWithIndex.flatMap {
+        case (rowIndex: Int, rowIndexPtr: Int) =>
+          if (rowIndex == prevRowIndex) {
+            Iterator.empty
+          } else {
+            val headElem = new SparseVector(numCols,
+              colIndices.slice(prevRowIndexPtr * 3, rowIndexPtr * 3)
+                .grouped(3).map(x => get24BitInt(x, 0)).toArray,
+              values.slice(prevRowIndexPtr, rowIndexPtr).map(_.toDouble)
+            )
+            assert(rowIndex > prevRowIndex)
+
+            val emptyRowIter = Iterator.continually(zeroRow).take(rowIndex - prevRowIndex - 1)
+
+            prevRowIndex = rowIndex
+            prevRowIndexPtr = rowIndexPtr
+
+            Iterator.single(headElem) ++ emptyRowIter
+          }
+      }
+      Iterator.continually(zeroRow).take(prevRowIndex) ++ iter
+    }
+  }
+
+  override def numActives: Int = values.length
+
+  override private[spark] def foreachActive(f: (Int, Int, Double) => Unit): Unit = {
+    var i = 0
+    while (i < values.length) {
+      f(get24BitInt(rowIndices, i), get24BitInt(colIndices, i), values(i))
+      i += 1
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/ml/linalg/VMatrix.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/VMatrix.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.linalg
+
+import java.util.Arrays
+
+/**
+ * Row major COO format matrix.
+ * It will use less storage space than `ml.linalg.SparseMatrix`,
+ * when the matrix is extremely sparse (for example, each row contains less than one
+ * nonzero element in average)
+ */
+
+trait VMatrix extends Serializable {
+
+  def numRows: Int
+
+  def numCols: Int
+
+  def rowIter: Iterator[Vector]
+
+  def numActives: Int
+
+  // A basic implementation, not use binary search.
+  def apply(i: Int, j: Int): Double = {
+    assert(i >= 0 && i < numRows && j >= 0 && j <= numCols)
+    var elemVal = 0.0
+    foreachActive { case (vi: Int, vj: Int, value: Double) =>
+      if (vi == i && vj == j) {
+        elemVal = value
+      }
+    }
+    elemVal
+  }
+
+  private[spark] def foreachActive(f: (Int, Int, Double) => Unit)
+
+}
+
+object VMatrices {
+
+  def COO(numRows: Int, numCols: Int, entries: Iterable[(Int, Int, Double)],
+          compressed: Boolean = false): VMatrix = {
+    val sortedEntries = entries.toSeq.sortBy(v => (v._1, v._2)) // sort by row major order.
+
+    if (!compressed) {
+      val rowIndices = new Array[Int](sortedEntries.length)
+      val colIndices = new Array[Int](sortedEntries.length)
+      val values = new Array[Double](sortedEntries.length)
+
+      var ptr = 0
+      sortedEntries.foreach { case (rowIndex: Int, colIndex: Int, value: Double) =>
+        rowIndices(ptr) = rowIndex
+        colIndices(ptr) = colIndex
+        values(ptr) = value
+        ptr += 1
+      }
+
+      new VCOOMatrix(numRows, numCols, rowIndices, colIndices, values)
+    } else {
+      val rowIndices = new Array[Int](sortedEntries.length)
+      val colIndices = new Array[Int](sortedEntries.length)
+      val values = new Array[Float](sortedEntries.length)
+
+      var ptr = 0
+      sortedEntries.foreach { case (rowIndex: Int, colIndex: Int, value: Double) =>
+        rowIndices(ptr) = rowIndex
+        colIndices(ptr) = colIndex
+        values(ptr) = value.toFloat
+        ptr += 1
+      }
+
+      def intTo24Bit = (v: Int) => Array((v & 255).toByte, ((v >> 8) & 255).toByte, ((v >> 16) & 255).toByte)
+
+      new VCompressedCOOMatrix(numRows, numCols,
+        rowIndices.flatMap(x => intTo24Bit(x)),
+        colIndices.flatMap(x => intTo24Bit(x)), values)
+    }
+  }
+
+}

--- a/src/main/scala/org/apache/spark/ml/linalg/distributed/DistributedVector.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/distributed/DistributedVector.scala
@@ -210,7 +210,7 @@ class DistributedVector(
     var oldBlocks: RDD[Vector] = null
     if (isRDDAlreadyComputed) {
       val checkpointValues = values.map(x => x)
-      checkpointValues.persist().checkpoint()
+      checkpointValues.persist(StorageLevel.MEMORY_AND_DISK).checkpoint()
       oldBlocks = values
       values = checkpointValues
     } else {

--- a/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
+++ b/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
@@ -34,7 +34,7 @@ private[spark] class VRDDFunctions[A](self: RDD[A])
   def mapJoinPartition[B: ClassTag, V: ClassTag](rdd2: RDD[B], shuffleRdd2: Boolean = true)(
     idxF: (Int) => Array[Int],
     f: (Int, Iterator[A], Array[(Int, Iterator[B])]) => Iterator[V]
-  ) = self.withScope{
+  ): RDD[V] = self.withScope{
     val sc = self.sparkContext
     val cleanIdxF = sc.clean(idxF)
     val cleanF = sc.clean(f)
@@ -42,7 +42,7 @@ private[spark] class VRDDFunctions[A](self: RDD[A])
       new MapJoinPartitionsRDDV2(sc, cleanIdxF, cleanF, self, rdd2)
     }
     else {
-       logWarning("mapJoinPartition not shuffle RDD2")
+      logWarning("mapJoinPartition not shuffle RDD2")
       new MapJoinPartitionsRDD(sc, cleanIdxF, cleanF, self, rdd2)
     }
   }

--- a/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
@@ -294,6 +294,33 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
     assert(vmodel.coefficients ~== model.coefficients relTol 1e-3)
   }
 
+  test("test on testData1, w/ weight, L2 reg = 0.8, w/o standardize, w/o intercept, compress features") {
+
+    val vtrainer = new VLogisticRegression()
+      .setFitIntercept(false)
+      .setColsPerBlock(4)
+      .setRowsPerBlock(5)
+      .setGeneratingFeatureMatrixBuffer(2)
+      .setWeightCol("weight")
+      .setRegParam(0.8)
+      .setStandardization(false)
+      .setEagerPersist(false)
+      .setCompressFeatureMatrix(true)
+    val vmodel = vtrainer.fit(testData1)
+
+    val trainer = new LogisticRegression()
+      .setFitIntercept(false)
+      .setWeightCol("weight")
+      .setRegParam(0.8)
+      .setStandardization(false)
+    val model = trainer.fit(testData1)
+    logInfo(s"LogisticRegression total iterations: ${model.summary.totalIterations}")
+
+    println(s"VLogisticRegression coefficients: ${vmodel.coefficients}\n" +
+      s"LogisticRegression coefficient: ${model.coefficients}")
+    assert(vmodel.coefficients ~== model.coefficients relTol 1e-3)
+  }
+
   test("test on testData1, w/ weight, reg = 0.8, elasticNet = 1.0, w/ standardize, w/o intercept") {
 
     val vtrainer = new VLogisticRegression()

--- a/src/test/scala/org/apache/spark/ml/linalg/VMatrixSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/linalg/VMatrixSuite.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.linalg
+
+import org.apache.spark.SparkFunSuite
+
+import scala.collection.mutable.ArrayBuffer
+
+class VMatrixSuite extends SparkFunSuite {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  test ("rowIter") {
+
+    for (compressed <- List(false, true)) {
+      val emptyRow = Vectors.sparse(4, new Array[(Int, Double)](0))
+
+      assert(VMatrices.COO(3, 4, new Array[(Int, Int, Double)](0), compressed).rowIter.toArray ===
+        Array(emptyRow, emptyRow, emptyRow)
+      )
+
+      assert(VMatrices.COO(3, 4, Array((2, 2, 4.0), (2, 3, 5.0), (0, 1, 2.0), (0, 3, 3.0)), compressed)
+        .rowIter.toArray ===
+        Array(
+          Vectors.sparse(4, Array((1, 2.0), (3, 3.0))),
+          emptyRow,
+          Vectors.sparse(4, Array((2, 4.0), (3, 5.0)))
+        ))
+
+      assert(VMatrices.COO(6, 4, Array((1, 1, 2.0), (1, 3, 3.0), (4, 1, 7.0)), compressed)
+        .rowIter.toArray ===
+        Array(
+          emptyRow,
+          Vectors.sparse(4, Array((1, 2.0), (3, 3.0))),
+          emptyRow,
+          emptyRow,
+          Vectors.sparse(4, Array((1, 7.0))),
+          emptyRow
+        )
+      )
+    }
+    assert(VMatrices.COO(8401234, 7105678, Array((70000, 7000000, 2.0),
+      (8400000, 6999999, 7.0), (8400000, 125, 3.0), (255, 2, 4.0), (254, 65050, 5.0)), true)
+      .rowIter.zipWithIndex.filter(_._1.numActives > 0).toArray ===
+      Array(
+        (Vectors.sparse(7105678, Array((65050, 5.0))), 254),
+        (Vectors.sparse(7105678, Array((2, 4.0))), 255),
+        (Vectors.sparse(7105678, Array((7000000, 2.0))), 70000),
+        (Vectors.sparse(7105678, Array((125, 3.0), (6999999, 7.0))), 8400000)
+      )
+    )
+  }
+
+  test ("fromCOO && apply && foreach") {
+
+    for (compressed <- List(false, true)) {
+      val mat = VMatrices.COO(8401234, 7105678, Array((70000, 7000000, 2.0),
+        (8400000, 6999999, 7.0), (8400000, 125, 3.0), (255, 2, 4.0), (254, 65050, 5.0)), true)
+      assert(mat(255, 666666) == 0.0 && mat(70000, 7000000) == 2.0 && mat(8400000, 125) == 3.0
+        && mat(255, 2) == 4.0 && mat(254, 65050) == 5.0)
+
+      val buff = new ArrayBuffer[(Int, Int, Double)]()
+      mat.foreachActive { case (i: Int, j: Int, value: Double) =>
+        buff += Tuple3(i, j, value)
+      }
+      assert(buff.toArray === Array((254, 65050, 5.0), (255, 2, 4.0), (70000, 7000000, 2.0),
+        (8400000, 125, 3.0), (8400000, 6999999, 7.0)))
+    }
+  }
+
+}


### PR DESCRIPTION
Add COO storage format for sparse matrix.
It will save memory for V-LOR when dimension scales to billions, at the same time won't reduce performance.
The reason is that `colPtrs` array in CSS format matrix will occupy large memory size when the matrix is very sparse.