### PR TITLE
Improve VLBFGS VOWLQN checkpoint

### DIFF
--- a/src/main/scala/org/apache/spark/ml/example/RosenbrockExample.scala
+++ b/src/main/scala/org/apache/spark/ml/example/RosenbrockExample.scala
@@ -70,7 +70,7 @@ object RosenbrockExample {
 
     var dfcallCnt = 0
     val vf_df = new VDiffFunction(eagerPersist) {
-      def calculate(x: DistributedVector) = {
+      def calculate(x: DistributedVector, checkAndMarkCheckpoint: DistributedVector => Unit) = {
         dfcallCnt += 1
         val r = calc(new BDV(x.toLocal.toArray))
         val rr = r._2.toArray

--- a/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/classification/VLogisticRegressionSuite.scala
@@ -521,7 +521,7 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
     assert(vmodel.intercept ~== model.intercept relTol 1e-3)
   }
 
-  test("test on testData1WithIntecept, w/ weight, reg = 0.8, elasticNet = 1.0, w/ standardize, w/ intercept") {
+  test("test on testData1WithIntecept, w/ weight, reg = 0.9, elasticNet = 0.1, w/ standardize, w/ intercept") {
 
     val vtrainer = new VLogisticRegression()
       .setFitIntercept(true)
@@ -530,8 +530,8 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
       .setColPartitions(3)
       .setRowPartitions(2)
       .setWeightCol("weight")
-      .setRegParam(0.8)
-      .setElasticNetParam(1.0)
+      .setRegParam(0.9)
+      .setElasticNetParam(0.1)
       .setStandardization(true)
       .setEagerPersist(false)
     val vmodel = vtrainer.fit(testData1WithIntecept)
@@ -539,8 +539,8 @@ class VLogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext 
     val trainer = new LogisticRegression()
       .setFitIntercept(true)
       .setWeightCol("weight")
-      .setRegParam(0.8)
-      .setElasticNetParam(1.0)
+      .setRegParam(0.9)
+      .setElasticNetParam(0.1)
       .setStandardization(true)
     val model = trainer.fit(testData1WithIntecept)
     logInfo(s"LogisticRegression total iterations: ${model.summary.totalIterations}")

--- a/src/test/scala/org/apache/spark/ml/linalg/distributed/DistributedVectorSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/linalg/distributed/DistributedVectorSuite.scala
@@ -29,9 +29,11 @@ class DistributedVectorSuite extends SparkFunSuite with MLlibTestSparkContext {
   var BV1: BDV[Double] = null
   var BV2: BDV[Double] = null
   var BV3: BDV[Double] = null
+  var BV4: BDV[Double] = null
   var DV1: DistributedVector = null
   var DV2: DistributedVector = null
   var DV3: DistributedVector = null
+  var DV4: DistributedVector = null
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -39,10 +41,12 @@ class DistributedVectorSuite extends SparkFunSuite with MLlibTestSparkContext {
     val v1: Array[Double] = Seq(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0).toArray
     val v2: Array[Double] = Seq(-1.0, -2.0, 3.0, 5.0, 6.0, 7.0, 8.0, 9.0).toArray
     val v3: Array[Double] = Seq(-1.0, -2.0, -3.0, 5.0, -6.0, 7.0, 8.0, 9.0).toArray
+    val v4: Array[Double] = Seq(0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 8.0, 0.0).toArray
 
     BV1 = new BDV(v1)
     BV2 = new BDV(v2)
     BV3 = new BDV(v3)
+    BV4 = new BDV(v4)
 
     val sizePerPart = 3
     val numPartitions = VUtils.getNumBlocks(sizePerPart, v1.length)
@@ -50,11 +54,14 @@ class DistributedVectorSuite extends SparkFunSuite with MLlibTestSparkContext {
     DV1 = VUtils.splitArrIntoDV(sc, v1, sizePerPart, numPartitions).persist()
     DV2 = VUtils.splitArrIntoDV(sc, v2, sizePerPart, numPartitions).persist()
     DV3 = VUtils.splitArrIntoDV(sc, v3, sizePerPart, numPartitions).persist()
+    DV4 = VUtils.splitArrIntoDV(sc, v4, sizePerPart, numPartitions).persist()
   }
 
   test("toLocal") {
     val localDV1 = DV1.toLocal
     assert(localDV1 ~== Vectors.fromBreeze(BV1) relTol 1e-8)
+    val localDV4 = DV4.compressed.toLocal
+    assert(localDV4 ~== Vectors.fromBreeze(BV4) relTol 1e-8)
   }
 
   test("add") {


### PR DESCRIPTION
Improve  VLBFGS VOWLQN checkpoint, set checkpoint before job run on RDD (the previous solution is generate a pseudo RDD `rdd.map(x => x) to set checkpoint), improve effieciency.