### PR TITLE
Improve VLBFGS DV dot precomputation

### DIFF
--- a/src/main/scala/org/apache/spark/ml/classification/VLogisticRegression.scala
+++ b/src/main/scala/org/apache/spark/ml/classification/VLogisticRegression.scala
@@ -241,7 +241,7 @@ class VLogisticRegression(override val uid: String)
   setDefault(elasticNetParam -> 0.0)
 
   def setCheckpointInterval(interval: Int): this.type = set(checkpointInterval, interval)
-  setDefault(checkpointInterval, 15)
+  setDefault(checkpointInterval, 30)
 
   def setGeneratingFeatureMatrixBuffer(size: Int): this.type =
     set(generatingFeatureMatrixBuffer, size)

--- a/src/main/scala/org/apache/spark/ml/example/VLORExample.scala
+++ b/src/main/scala/org/apache/spark/ml/example/VLORExample.scala
@@ -44,6 +44,8 @@ object VLORExample {
     var correctionNumber: Int = 10
     var compressFeatures: Boolean = false
 
+    var checkpointInterval: Int = 15
+
     try {
       maxIter = args(0).toInt
       dimension = args(1).toInt
@@ -60,6 +62,7 @@ object VLORExample {
       waitEnterPressingOnExit = args(12).toBoolean
       correctionNumber = args(13).toInt
       compressFeatures = args(14).toBoolean
+      checkpointInterval = args(15).toInt
     } catch {
       case _: Throwable =>
         println("Param list: "
@@ -81,7 +84,8 @@ object VLORExample {
           "\ndataPath         training data path on HDFS" +
           "\nwaitEnterPressingOnExit    whether need press enter to exit." +
           "\ncorrectionNumber       correction number for LBFGS" +
-          "\ncompressFeatures       whether to compress features using float"
+          "\ncompressFeatures       whether to compress features using float" +
+          "\ncheckpointInterval     checkpoint interval"
         )
 
         System.exit(-1)
@@ -114,6 +118,7 @@ object VLORExample {
         .setRowPartitionSplitNumOnGeneratingFeatureMatrix(rowPartitionSplitNumOnGeneratingFeatureMatrix)
         .setNumCorrections(correctionNumber)
         .setCompressFeatureMatrix(compressFeatures)
+        .setCheckpointInterval(checkpointInterval)
       val vmodel = vtrainer.fit(dataset)
 
       println(s"VLOR done, coeffs non zeros: ${vmodel.coefficients.numNonzeros}")


### PR DESCRIPTION
use `union` + `repartition` instead of custom `zipMultiRdds` operator. In VLBFGS direction computation.