### PR TITLE
optimize the logic of creating COO matrix from another COO matrix. 

### DIFF
--- a/src/main/scala/org/apache/spark/ml/classification/VLogisticRegression.scala
+++ b/src/main/scala/org/apache/spark/ml/classification/VLogisticRegression.scala
@@ -17,16 +17,14 @@
 
 package org.apache.spark.ml.classification
 
-import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.feature.Instance
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.linalg.distributed._
 import org.apache.spark.ml.optim.{VDiffFunction, VLBFGS, VOWLQN}
-import org.apache.spark.ml.param.{BooleanParam, IntParam, ParamMap, ParamValidators}
+import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
-import org.apache.spark.mllib.stat.OptimMultivariateOnlineSummarizer
 import org.apache.spark.SparkException
 import org.apache.spark.ml.VParams
 import org.apache.spark.mllib.util.MLUtils

--- a/src/main/scala/org/apache/spark/ml/example/VLORRealDataExample.scala
+++ b/src/main/scala/org/apache/spark/ml/example/VLORRealDataExample.scala
@@ -20,7 +20,6 @@ package org.apache.spark.ml.example
 import org.apache.spark.ml.classification.{LogisticRegression, VLogisticRegression}
 import org.apache.spark.sql.{Dataset, SparkSession}
 
-
 object VLORRealDataExample {
 
   // https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html#a9a

--- a/src/main/scala/org/apache/spark/ml/linalg/VCOOMatrix.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/VCOOMatrix.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.linalg
 
-import java.util.Arrays
-
 /**
  * Row major COO format matrix.
  * It will use less storage space than `ml.linalg.SparseMatrix`,

--- a/src/main/scala/org/apache/spark/ml/linalg/distributed/DistributedVector.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/distributed/DistributedVector.scala
@@ -49,13 +49,13 @@ class DistributedVector(
       && size == other.size)
 
     val resValues = values.zip(other.values).map { case (vec1: Vector, vec2: Vector) =>
-        val vec3 = if (vec1.isInstanceOf[DenseVector]) {
-          vec1.copy
-        } else {
-          vec1.toDense
-        }
-        BLAS.axpy(a, vec2, vec3)
-        vec3
+      val vec3 = if (vec1.isInstanceOf[DenseVector]) {
+        vec1.copy
+      } else {
+        vec1.toDense
+      }
+      BLAS.axpy(a, vec2, vec3)
+      vec3
     }
     new DistributedVector(resValues, sizePerPart, numPartitions, size)
   }
@@ -111,7 +111,7 @@ class DistributedVector(
 
   def toKVRDD: RDD[(Int, Vector)] = {
     values.mapPartitionsWithIndex { case (pid: Int, iter: Iterator[Vector]) =>
-        iter.map(v => (pid, v))
+      iter.map(v => (pid, v))
     }
   }
 
@@ -333,7 +333,8 @@ object DistributedVectors {
     val sizePerPart = firstDV.sizePerPart
     val size = firstDV.size
 
-    val combinedValues = rddList.head.context.union(rddList).aggregateByKey(
+    val combinedValues = rddList.head.context.union(rddList)
+      .aggregateByKey(
       new ScaledVectorAggregator,
       new DistributedVectorPartitioner(numPartitions)
     )((sva: ScaledVectorAggregator, instance: (Double, Vector)) => sva.add(instance),

--- a/src/main/scala/org/apache/spark/ml/linalg/distributed/VBlockMatrix.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/distributed/VBlockMatrix.scala
@@ -36,8 +36,7 @@ class VBlockMatrix(
     System.getProperty("vflbfgs.mapJoinPartitions.shuffleRdd2", "true").toBoolean
 
   def horizontalZipVector[T: ClassTag](vector: DistributedVector)(
-      f: (((Int, Int), VMatrix, Vector) => T)
-    ): RDD[((Int, Int), T)] = {
+      f: (((Int, Int), VMatrix, Vector) => T)): RDD[((Int, Int), T)] = {
 
     import org.apache.spark.rdd.VRDDFunctions._
 
@@ -57,9 +56,9 @@ class VBlockMatrix(
        vIter: Array[(Int, Iterator[Vector])]) => {
         val vMap = new HashMap[Int, Vector]
         util.Random.shuffle(vIter.toList).foreach { case (colId: Int, iter: Iterator[Vector]) =>
-            val v = iter.next()
-            assert(!iter.hasNext)
-            vMap += (colId -> v)
+          val v = iter.next()
+          assert(!iter.hasNext)
+          vMap += (colId -> v)
         }
         mIter.map { case ((rowBlockIdx: Int, colBlockIdx: Int), sm: VMatrix) =>
           val partVector = vMap(colBlockIdx)
@@ -70,8 +69,7 @@ class VBlockMatrix(
   }
 
   def verticalZipVector[T: ClassTag](vec: DistributedVector)(
-      f: (((Int, Int), VMatrix, Vector) => T)
-    ): RDD[((Int, Int), T)] = {
+      f: (((Int, Int), VMatrix, Vector) => T)): RDD[((Int, Int), T)] = {
 
     import org.apache.spark.rdd.VRDDFunctions._
 
@@ -103,15 +101,13 @@ class VBlockMatrix(
   }
 
   def horizontalZipVector2(vector: DistributedVector)(
-    f: (((Int, Int), VMatrix, Vector) => VMatrix)
-  ): VBlockMatrix = {
+      f: (((Int, Int), VMatrix, Vector) => VMatrix)): VBlockMatrix = {
     val newBlocks = horizontalZipVector(vector)(f)
     new VBlockMatrix(rowsPerBlock, colsPerBlock, newBlocks, gridPartitioner)
   }
 
   def verticalZipVector2(vector: DistributedVector)(
-    f: (((Int, Int), VMatrix, Vector) => VMatrix)
-  ): VBlockMatrix = {
+      f: (((Int, Int), VMatrix, Vector) => VMatrix)): VBlockMatrix = {
     val newBlocks = verticalZipVector(vector)(f)
     new VBlockMatrix(rowsPerBlock, colsPerBlock, newBlocks, gridPartitioner)
   }

--- a/src/main/scala/org/apache/spark/ml/optim/VLBFGS.scala
+++ b/src/main/scala/org/apache/spark/ml/optim/VLBFGS.scala
@@ -70,7 +70,8 @@ class VLBFGS(
   protected def determineAndTakeStepSize(
       state: State,
       fn: VDiffFunction,
-      direction: DistributedVector): (Double, Double, DistributedVector, DistributedVector, DistributedVector) = {
+      direction: DistributedVector
+    ): (Double, Double, DistributedVector, DistributedVector, DistributedVector) = {
     // using strong wolfe line search
     val grad = state.grad
 
@@ -140,7 +141,8 @@ class VLBFGS(
     }
   }
 
-  protected def initialState(fn: VDiffFunction, init: DistributedVector, checkpointInterval: Int): State = {
+  protected def initialState(
+      fn: VDiffFunction, init: DistributedVector, checkpointInterval: Int): State = {
     val x = init
     val (value, grad) = fn.calculate(x, null)
     val (adjValue, adjGrad) = adjust(null, x, grad, value)
@@ -587,5 +589,5 @@ abstract class VDiffFunction(eagerPersist: Boolean = true) { outer =>
 
   // Calculates both the value and the gradient at a point
   def calculate(x: DistributedVector, checkAndMarkCheckpoint: DistributedVector => Unit):
-  (Double, DistributedVector)
+    (Double, DistributedVector)
 }

--- a/src/main/scala/org/apache/spark/ml/optim/VOWLQN.scala
+++ b/src/main/scala/org/apache/spark/ml/optim/VOWLQN.scala
@@ -289,7 +289,8 @@ class VOWLQN (
   override protected def determineAndTakeStepSize(
       state: State,
       fn: VDiffFunction,
-      direction: DistributedVector): (Double, Double, DistributedVector, DistributedVector, DistributedVector) = {
+      direction: DistributedVector
+    ): (Double, Double, DistributedVector, DistributedVector, DistributedVector) = {
 
     val lineSearchDiffFn = new VOWLQNLineSearchDiffFun(state, direction, fn, eagerPersist)
 

--- a/src/main/scala/org/apache/spark/ml/tools/VLORDataGenerator.scala
+++ b/src/main/scala/org/apache/spark/ml/tools/VLORDataGenerator.scala
@@ -35,8 +35,11 @@ object VLORDataGenerator {
     coeffs
   }
 
-  def genRecord(rnd: Random, coeffs: Array[Double],
-                dimension: Int, validFeatureNumPerRecord: Int): String = {
+  def genRecord(
+      rnd: Random,
+      coeffs: Array[Double],
+      dimension: Int,
+      validFeatureNumPerRecord: Int): String = {
 
     val idxBuf = ArrayBuffer[Int](validFeatureNumPerRecord)
     var i = 0
@@ -90,7 +93,8 @@ object VLORDataGenerator {
 
     } catch {
       case _: Throwable =>
-        println("Params: dimension numSplits numRecordsPerSplit validFeatureNumPerRecord seed outputPath")
+        println("Params: dimension numSplits numRecordsPerSplit validFeatureNumPerRecord " +
+          "seed outputPath")
         System.exit(-1)
     }
 

--- a/src/main/scala/org/apache/spark/rdd/VOrderedRDDFunctions.scala
+++ b/src/main/scala/org/apache/spark/rdd/VOrderedRDDFunctions.scala
@@ -33,7 +33,7 @@ class VOrderedRDDFunctions[K, V](self: RDD[(K, V)])
         new Iterator[(K, CompactBuffer[V])] {
           private var firstElemInNextGroup: (K, V) = null
 
-          override def hasNext: Boolean = (firstElemInNextGroup != null || iter.hasNext)
+          override def hasNext: Boolean = firstElemInNextGroup != null || iter.hasNext
 
           override def next(): (K, CompactBuffer[V]) = {
             if (firstElemInNextGroup == null) {

--- a/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
+++ b/src/main/scala/org/apache/spark/rdd/VRDDFunctions.scala
@@ -117,7 +117,8 @@ class VPairRDDFunctions[K, V](self: RDD[(K, V)])
           createZero()
         }
         hashMap.update(key, seqOp(combinedValue, value))
-        System.err.println(s"thread: ${Thread.currentThread().getId} idx: ${iterIndex}, estimate aggr map: ${SizeEstimator.estimate(hashMap)}")
+        System.err.println(s"thread: ${Thread.currentThread().getId} idx: $iterIndex, " +
+          s"estimate aggr map: ${SizeEstimator.estimate(hashMap)}")
         iterIndex += 1
       }
       val res = hashMap.toIterator

--- a/src/test/scala/org/apache/spark/ml/linalg/VMatrixSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/linalg/VMatrixSuite.scala
@@ -32,11 +32,11 @@ class VMatrixSuite extends SparkFunSuite {
     for (compressed <- List(false, true)) {
       val emptyRow = Vectors.sparse(4, new Array[(Int, Double)](0))
 
-      assert(VMatrices.COO(3, 4, new Array[(Int, Int, Double)](0), compressed).rowIter.toArray ===
+      assert(VMatrices.COOEntries(3, 4, new Array[(Int, Int, Double)](0), compressed).rowIter.toArray ===
         Array(emptyRow, emptyRow, emptyRow)
       )
 
-      assert(VMatrices.COO(3, 4, Array((2, 2, 4.0), (2, 3, 5.0), (0, 1, 2.0), (0, 3, 3.0)), compressed)
+      assert(VMatrices.COOEntries(3, 4, Array((2, 2, 4.0), (2, 3, 5.0), (0, 1, 2.0), (0, 3, 3.0)), compressed)
         .rowIter.toArray ===
         Array(
           Vectors.sparse(4, Array((1, 2.0), (3, 3.0))),
@@ -44,7 +44,7 @@ class VMatrixSuite extends SparkFunSuite {
           Vectors.sparse(4, Array((2, 4.0), (3, 5.0)))
         ))
 
-      assert(VMatrices.COO(6, 4, Array((1, 1, 2.0), (1, 3, 3.0), (4, 1, 7.0)), compressed)
+      assert(VMatrices.COOEntries(6, 4, Array((1, 1, 2.0), (1, 3, 3.0), (4, 1, 7.0)), compressed)
         .rowIter.toArray ===
         Array(
           emptyRow,
@@ -56,7 +56,7 @@ class VMatrixSuite extends SparkFunSuite {
         )
       )
     }
-    assert(VMatrices.COO(8401234, 7105678, Array((70000, 7000000, 2.0),
+    assert(VMatrices.COOEntries(8401234, 7105678, Array((70000, 7000000, 2.0),
       (8400000, 6999999, 7.0), (8400000, 125, 3.0), (255, 2, 4.0), (254, 65050, 5.0)), true)
       .rowIter.zipWithIndex.filter(_._1.numActives > 0).toArray ===
       Array(
@@ -71,7 +71,7 @@ class VMatrixSuite extends SparkFunSuite {
   test ("fromCOO && apply && foreach") {
 
     for (compressed <- List(false, true)) {
-      val mat = VMatrices.COO(8401234, 7105678, Array((70000, 7000000, 2.0),
+      val mat = VMatrices.COOEntries(8401234, 7105678, Array((70000, 7000000, 2.0),
         (8400000, 6999999, 7.0), (8400000, 125, 3.0), (255, 2, 4.0), (254, 65050, 5.0)), true)
       assert(mat(255, 666666) == 0.0 && mat(70000, 7000000) == 2.0 && mat(8400000, 125) == 3.0
         && mat(255, 2) == 4.0 && mat(254, 65050) == 5.0)

--- a/src/test/scala/org/apache/spark/ml/linalg/distributed/VBlockMatrixSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/linalg/distributed/VBlockMatrixSuite.scala
@@ -39,7 +39,7 @@ class VBlockMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
       val rowBlockIdx = idx % rowBlocks
       val colBlockIdx = idx / rowBlocks
       ((rowBlockIdx, colBlockIdx),
-        VMatrices.COO(1, 2, Array((0, 0, rowBlockIdx.toDouble),
+        VMatrices.COOEntries(1, 2, Array((0, 0, rowBlockIdx.toDouble),
           (0, 1, colBlockIdx.toDouble))))
     }
     val gridPartitioner = VGridPartitioner(rowBlocks, colBlocks, rowBlocksPerPart, colBlocksPerPart)
@@ -77,7 +77,7 @@ class VBlockMatrixSuite extends SparkFunSuite with MLlibTestSparkContext {
       val rowBlockIdx = idx % rowBlocks
       val colBlockIdx = idx / rowBlocks
       ((rowBlockIdx, colBlockIdx),
-        VMatrices.COO(1, 2, Array((0, 0, rowBlockIdx.toDouble),
+        VMatrices.COOEntries(1, 2, Array((0, 0, rowBlockIdx.toDouble),
           (0, 1, colBlockIdx.toDouble))))
     }
     val gridPartitioner = VGridPartitioner(rowBlocks, colBlocks, rowBlocksPerPart, colBlocksPerPart)


### PR DESCRIPTION
> The main change is to optimize the logic of creating COO matrix from another COO matrix. As the row indices and column indices is sorted when be created, so we can use the sub-array directly to create another COO matrix without sorting them. 

> Besides,  this pr fixed some code style issues.

No new unit test is added and all unit test passed.