### PR TITLE
Avoid use ArrayBuffer to create COO format matrix. 

### DIFF
--- a/src/main/scala/org/apache/spark/ml/util/VUtils.scala
+++ b/src/main/scala/org/apache/spark/ml/util/VUtils.scala
@@ -279,9 +279,8 @@ private[spark] object VUtils {
                 val blockColIndex = colIndex / colsPerBlock
                 buffArr(blockColIndex) += 1
               }
-              if (inBlockRowIndex == rowsPerBlock - 1 ||
-                inBlockRowIndex % generatingFeatureMatrixBuffer ==
-                  generatingFeatureMatrixBuffer - 1
+              if (inBlockRowIndex == rowsPerBlock - 1
+                || inBlockRowIndex % generatingFeatureMatrixBuffer == generatingFeatureMatrixBuffer - 1
               ) {
                 shouldBreak = true
               }
@@ -351,7 +350,7 @@ private[spark] object VUtils {
                 idx(i) = 0
               }
               val buffArr = Array.tabulate(colBlocks) { i =>
-                // Give each array with a determinate size
+                // Create each array with a determinate size.
                 Tuple3(
                   new Array[Int](activeInBlock.apply(n)(i)._2),
                   new Array[Int](activeInBlock.apply(n)(i)._2),
@@ -377,9 +376,8 @@ private[spark] object VUtils {
                   COOBuffTuple._3(m) = value
                   idx(blockColIndex) += 1
                 }
-                if (inBlockRowIndex == rowsPerBlock - 1 ||
-                  inBlockRowIndex % generatingFeatureMatrixBuffer ==
-                    generatingFeatureMatrixBuffer - 1
+                if (inBlockRowIndex == rowsPerBlock - 1
+                  || inBlockRowIndex % generatingFeatureMatrixBuffer == generatingFeatureMatrixBuffer - 1
                 ) {
                   shouldBreak = true
                 }


### PR DESCRIPTION
## Before PR
 As we do not know how many active feature in each block, we use the mutable scala array, i.e. ArrayBuffer, to hold row, column and value data.

## After PR
We add a pre-work to count the active feature in each block. Then we can create determinate size array. This change can help to avoid doing once transform, i.e. from ArrayBuffer to Array, and then help to improve the heap memory usage issue, like gc.

## Benchmark

Here is some test result in local env:

- data set: 200 million (rows) x  1 billion (feature)
- cluster setup: 20 x 32(cores) x 128GB 
- @ Alibaba Cloud E-MapReduce

|   \ | before pr | after pr |
|---|-----------|--------|
| Task duration (with gc issue) |2.3~2.8min|16~20s|
|  GC duration|1.8~2.6min|<5s|

## Followups

new unit test for change?

## Unit Test

all tests passed.